### PR TITLE
chore:clean up package management

### DIFF
--- a/apps/storybook/.eslintrc.js
+++ b/apps/storybook/.eslintrc.js
@@ -1,1 +1,1 @@
-module.exports = require("config/.eslintrc");
+module.exports = require("@eden/package-config/.eslintrc");

--- a/apps/storybook/.storybook/decorator.tsx
+++ b/apps/storybook/.storybook/decorator.tsx
@@ -1,11 +1,11 @@
 import { Story } from "@storybook/react";
-import { UserContext } from "@context/eden";
+import { UserContext } from "@eden/package-context";
 import { SessionProvider } from "next-auth/react";
 
 import { ApolloProvider } from "@apollo/client";
-import { apolloClient } from "@graphql/eden";
+import { apolloClient } from "@eden/package-graphql";
 import { getMember } from "../mocks";
-import { Members } from "@graphql/eden/generated";
+import { Members } from "@eden/package-graphql/generated";
 
 /**
  * A storybook decorator which wraps components in a mock apollo context.

--- a/apps/storybook/mocks/MembersMock.ts
+++ b/apps/storybook/mocks/MembersMock.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { PhaseType } from "@graphql/eden/generated";
+import { PhaseType } from "@eden/package-graphql/generated";
 
 import { phase, skills } from "./data";
 

--- a/apps/storybook/mocks/ProjectMock.ts
+++ b/apps/storybook/mocks/ProjectMock.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { PhaseType, Project } from "@graphql/eden/generated";
+import { PhaseType, Project } from "@eden/package-graphql/generated";
 
 import { phase, skills } from "./data";
 import { getMember } from "./MembersMock";

--- a/apps/storybook/mocks/data/findProjects_RecommendedToUser.ts
+++ b/apps/storybook/mocks/data/findProjects_RecommendedToUser.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { faker } from "@faker-js/faker";
-import { Maybe, ProjectMatchType } from "@graphql/eden/generated";
+import { Maybe, ProjectMatchType } from "@eden/package-graphql/generated";
 
 export const findProjects_RecommendedToUser: Maybe<ProjectMatchType> = {
   projectData: {

--- a/apps/storybook/mocks/data/findRoleTemplates.ts
+++ b/apps/storybook/mocks/data/findRoleTemplates.ts
@@ -1,4 +1,4 @@
-import { Maybe, RoleTemplate } from "@graphql/eden/generated";
+import { Maybe, RoleTemplate } from "@eden/package-graphql/generated";
 
 export const findRoleTemplates: Maybe<Array<Maybe<RoleTemplate>>> = [
   {

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",
+    "@eden/package-config": "*",
     "@storybook/addon-a11y": "^6.5.12",
     "@storybook/addon-actions": "^6.5.12",
     "@storybook/addon-essentials": "^6.5.12",
@@ -26,7 +27,6 @@
     "@storybook/react": "^6.5.12",
     "autoprefixer": "^10.4.12",
     "babel-loader": "^8.2.5",
-    "config": "*",
     "postcss": "^8.4.16",
     "postcss-loader": "^7.0.1",
     "storybook-addon-apollo-client": "^4.0.12",

--- a/apps/storybook/postcss.config.js
+++ b/apps/storybook/postcss.config.js
@@ -1,1 +1,1 @@
-module.exports = require("config/postcss.config");
+module.exports = require("@eden/package-config/postcss.config");

--- a/apps/storybook/tailwind.config.js
+++ b/apps/storybook/tailwind.config.js
@@ -1,3 +1,3 @@
-const config = require("config/tailwind.config.js");
+const config = require("@eden/package-config/tailwind.config.js");
 
 module.exports = config;

--- a/apps/web/.eslintrc.js
+++ b/apps/web/.eslintrc.js
@@ -1,1 +1,1 @@
-module.exports = require("config/.eslintrc");
+module.exports = require("@eden/package-config/.eslintrc");

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,7 @@
-const withTM = require("next-transpile-modules")(["ui", "@context/eden"]);
+const withTM = require("next-transpile-modules")([
+  "ui",
+  "@eden/package-context",
+]);
 
 module.exports = withTM({
   reactStrictMode: true,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.9",
-    "@context/eden": "*",
-    "@graphql/eden": "*",
+    "@eden/package-context": "*",
+    "@eden/package-graphql": "*",
     "graphql": "^16.6.0",
     "next": "12.2.0",
     "next-auth": "^4.12.0",
@@ -25,16 +25,16 @@
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",
+    "@eden/package-config": "*",
+    "@eden/package-tsconfig": "*",
     "@types/node": "^18.7.23",
     "@types/react": "^18.0.21",
     "autoprefixer": "^10.4.12",
-    "config": "*",
     "eslint": "^8.24.0",
     "next-transpile-modules": "9.0.0",
     "postcss": "^8.4.16",
     "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss": "^3.1.7",
-    "tsconfig": "*",
     "typescript": "^4.8.4"
   }
 }

--- a/apps/web/pages/_app.tsx
+++ b/apps/web/pages/_app.tsx
@@ -1,8 +1,8 @@
 import "../styles/global.css";
 
 import { ApolloProvider } from "@apollo/client";
-import { UserProvider } from "@context/eden";
-import { apolloClient } from "@graphql/eden";
+import { UserProvider } from "@eden/package-context";
+import { apolloClient } from "@eden/package-graphql";
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
 import { SessionProvider } from "next-auth/react";

--- a/apps/web/pages/admin/new-role-template/index.tsx
+++ b/apps/web/pages/admin/new-role-template/index.tsx
@@ -1,8 +1,15 @@
 /* eslint-disable camelcase */
 import { useMutation, useQuery } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { FIND_ROLE_TEMPLATES, UPDATE_ROLE_TEMPLATE } from "@graphql/eden";
-import { Maybe, RoleTemplate, SkillType_Member } from "@graphql/eden/generated";
+import { UserContext } from "@eden/package-context";
+import {
+  FIND_ROLE_TEMPLATES,
+  UPDATE_ROLE_TEMPLATE,
+} from "@eden/package-graphql";
+import {
+  Maybe,
+  RoleTemplate,
+  SkillType_Member,
+} from "@eden/package-graphql/generated";
 import { Combobox } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/solid";
 import { useContext, useState } from "react";

--- a/apps/web/pages/admin/new-sub-catagory/index.tsx
+++ b/apps/web/pages/admin/new-sub-catagory/index.tsx
@@ -1,17 +1,17 @@
 /* eslint-disable camelcase */
 import { useMutation, useQuery } from "@apollo/client";
-import { UserContext } from "@context/eden";
+import { UserContext } from "@eden/package-context";
 import {
   FIND_SKILL_CATEGORIES,
   UPDATE_SKILL_CATEGORY,
   UPDATE_SKILL_SUB_CATEGORY,
-} from "@graphql/eden";
+} from "@eden/package-graphql";
 import {
   Maybe,
   SkillCategory,
   SkillSubCategory,
   SkillType_Member,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { Combobox } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/solid";
 import { useContext, useState } from "react";

--- a/apps/web/pages/applications/index.tsx
+++ b/apps/web/pages/applications/index.tsx
@@ -1,4 +1,4 @@
-import { UserContext } from "@context/eden";
+import { UserContext } from "@eden/package-context";
 import { useContext } from "react";
 import { AppUserMenuLayout, Card, ProjectList } from "ui";
 

--- a/apps/web/pages/apply/[_id].tsx
+++ b/apps/web/pages/apply/[_id].tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@apollo/client";
-import { FIND_PROJECT } from "@graphql/eden";
+import { FIND_PROJECT } from "@eden/package-graphql";
 import { useRouter } from "next/router";
 import {
   ApplyContainer,

--- a/apps/web/pages/champion-board/index.tsx
+++ b/apps/web/pages/champion-board/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { FIND_PROJECT } from "@graphql/eden";
+import { UserContext } from "@eden/package-context";
+import { FIND_PROJECT } from "@eden/package-graphql";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 import {

--- a/apps/web/pages/champion-board/recruit/[_id].tsx
+++ b/apps/web/pages/champion-board/recruit/[_id].tsx
@@ -4,7 +4,7 @@ import {
   FIND_PROJECT,
   FIND_ROLE_TEMPLATES,
   MATCH_MEMBERS_TO_SKILLS,
-} from "@graphql/eden";
+} from "@eden/package-graphql";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import {

--- a/apps/web/pages/invites/[_id]/index.tsx
+++ b/apps/web/pages/invites/[_id]/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
-// import { UserContext } from "@context/eden";
-import { FIND_PROJECT } from "@graphql/eden";
+// import { UserContext } from "@eden/package-context";
+import { FIND_PROJECT } from "@eden/package-graphql";
 import { useRouter } from "next/router";
 // import { useContext } from "react";
 import { AppUserMenuLayout, InviteContainer } from "ui";

--- a/apps/web/pages/invites/index.tsx
+++ b/apps/web/pages/invites/index.tsx
@@ -1,4 +1,4 @@
-import { UserContext } from "@context/eden";
+import { UserContext } from "@eden/package-context";
 import { useContext } from "react";
 import { AppUserMenuLayout, Card, ProjectList } from "ui";
 

--- a/apps/web/pages/launch/index.tsx
+++ b/apps/web/pages/launch/index.tsx
@@ -1,5 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
-import { LaunchProvider } from "@context/eden";
+import { LaunchProvider } from "@eden/package-context";
 import {
   AppUserLayout,
   GridItemSix,

--- a/apps/web/pages/my-projects/[_id]/index.tsx
+++ b/apps/web/pages/my-projects/[_id]/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
-// import { UserContext } from "@context/eden";
-import { FIND_PROJECT } from "@graphql/eden";
+// import { UserContext } from "@eden/package-context";
+import { FIND_PROJECT } from "@eden/package-graphql";
 import { useRouter } from "next/router";
 // import { useContext } from "react";
 import { AppUserMenuLayout, MyProjectContainer } from "ui";

--- a/apps/web/pages/my-projects/index.tsx
+++ b/apps/web/pages/my-projects/index.tsx
@@ -1,4 +1,4 @@
-import { UserContext } from "@context/eden";
+import { UserContext } from "@eden/package-context";
 import { useContext } from "react";
 import { AppUserMenuLayout, Card, ProjectList } from "ui";
 

--- a/apps/web/pages/onboard/party/[partyId].tsx
+++ b/apps/web/pages/onboard/party/[partyId].tsx
@@ -1,14 +1,18 @@
 /* eslint-disable camelcase */
 import { gql, useMutation, useQuery, useSubscription } from "@apollo/client";
-import { UserContext } from "@context/eden";
+import { UserContext } from "@eden/package-context";
 import {
   ENTER_ROOM,
   FIND_ROOM,
   MEMBER_UPDATED,
   ROOM_UPDATED,
   UPDATE_MEMBER,
-} from "@graphql/eden";
-import { Maybe, Members, SkillType_Member } from "@graphql/eden/generated";
+} from "@eden/package-graphql";
+import {
+  Maybe,
+  Members,
+  SkillType_Member,
+} from "@eden/package-graphql/generated";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 import {

--- a/apps/web/pages/projects/index.tsx
+++ b/apps/web/pages/projects/index.tsx
@@ -1,6 +1,9 @@
 import { useQuery } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { FIND_PROJECTS, FIND_PROJECTS_RECOMMENDED } from "@graphql/eden";
+import { UserContext } from "@eden/package-context";
+import {
+  FIND_PROJECTS,
+  FIND_PROJECTS_RECOMMENDED,
+} from "@eden/package-graphql";
 import { useContext } from "react";
 import { AppUserMenuLayout, ProjectsContainer } from "ui";
 

--- a/apps/web/pages/signup/index.tsx
+++ b/apps/web/pages/signup/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { gql, useQuery } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { FIND_PROJECT } from "@graphql/eden";
+import { UserContext } from "@eden/package-context";
+import { FIND_PROJECT } from "@eden/package-graphql";
 import Head from "next/head";
 import { useContext, useState } from "react";
 import {

--- a/apps/web/pages/test-launch-2/index.tsx
+++ b/apps/web/pages/test-launch-2/index.tsx
@@ -1,4 +1,4 @@
-import { LaunchProjectProvider } from "@context/eden";
+import { LaunchProjectProvider } from "@eden/package-context";
 import {
   AppUserLayout,
   Card,

--- a/apps/web/pages/test-launch-2/shortlist-users/index.tsx
+++ b/apps/web/pages/test-launch-2/shortlist-users/index.tsx
@@ -3,7 +3,7 @@ import {
   LaunchProjectModal,
   LaunchProjectProvider,
   ProjectActionKind,
-} from "@context/eden";
+} from "@eden/package-context";
 import {
   AppUserLayout,
   Button,
@@ -131,8 +131,8 @@ LaunchPage.getLayout = (page) => (
 export default LaunchPage;
 
 import { useQuery } from "@apollo/client";
-import { MATCH_MEMBERS_TO_SKILLS } from "@graphql/eden";
-import { Maybe, Members, TeamType } from "@graphql/eden/generated";
+import { MATCH_MEMBERS_TO_SKILLS } from "@eden/package-graphql";
+import { Maybe, Members, TeamType } from "@eden/package-graphql/generated";
 import { IncomingMessage, ServerResponse } from "http";
 import { getSession } from "next-auth/react";
 import { useContext, useEffect } from "react";

--- a/apps/web/pages/test-launch/launch-project/index.tsx
+++ b/apps/web/pages/test-launch/launch-project/index.tsx
@@ -1,4 +1,4 @@
-import { LaunchProvider } from "@context/eden";
+import { LaunchProvider } from "@eden/package-context";
 import {
   AppUserLayout,
   Card,

--- a/apps/web/pages/test-launch/shortlist-users/[projectId].tsx
+++ b/apps/web/pages/test-launch/shortlist-users/[projectId].tsx
@@ -1,4 +1,4 @@
-import { LaunchProvider } from "@context/eden";
+import { LaunchProvider } from "@eden/package-context";
 import {
   AppUserLayout,
   Button,
@@ -429,7 +429,7 @@ import {
   FIND_ROLE_TEMPLATES,
   MATCH_MEMBERS_TO_SKILLS,
   UPDATE_PROJECT,
-} from "@graphql/eden";
+} from "@eden/package-graphql";
 import {
   InputMaybe,
   Maybe,
@@ -443,7 +443,7 @@ import {
   SkillRoleType,
   TeamInput,
   TeamType,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { IncomingMessage, ServerResponse } from "http";
 import { useRouter } from "next/router";
 import { getSession } from "next-auth/react";

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,1 +1,1 @@
-module.exports = require("config/postcss.config");
+module.exports = require("@eden/package-config/postcss.config");

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,3 +1,3 @@
-const config = require("config/tailwind.config.js");
+const config = require("@eden/package-config/tailwind.config.js");
 
 module.exports = config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/nextjs.json",
+  "extends": "@eden/package-tsconfig/nextjs.json",
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "codegen:eden": "turbo run codegen:eden"
   },
   "devDependencies": {
-    "config": "*",
+    "@eden/package-config": "*",
     "husky": "^8.0.0",
     "prettier": "latest",
     "prettier-plugin-tailwindcss": "^0.1.13",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "config",
+  "name": "@eden/package-config",
   "version": "0.0.0",
   "main": "index.js",
   "license": "MIT",
@@ -16,6 +16,7 @@
     "eslint-config-prettier": "^8.3.0"
   },
   "devDependencies": {
+    "@eden/package-tsconfig": "*",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "13.3.0",
     "@types/jest": "^28.1.6",
@@ -25,7 +26,6 @@
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.2",
     "tailwind-scrollbar-hide": "^1.1.7",
-    "ts-jest": "^28.0.7",
-    "tsconfig": "*"
+    "ts-jest": "^28.0.7"
   }
 }

--- a/packages/context/.eslintrc.js
+++ b/packages/context/.eslintrc.js
@@ -1,1 +1,1 @@
-module.exports = require("config/.eslintrc");
+module.exports = require("@eden/package-config/.eslintrc");

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@context/eden",
+  "name": "@eden/package-context",
   "version": "0.0.0",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -11,13 +11,13 @@
     "clean-windows": "rd /s /q node_modules"
   },
   "devDependencies": {
-    "@graphql/eden": "*",
+    "@eden/package-config": "*",
+    "@eden/package-graphql": "*",
+    "@eden/package-tsconfig": "*",
     "@types/node": "^18.6.1",
     "@types/react": "18.0.15",
     "@types/react-dom": "^18.0.6",
-    "config": "*",
     "eslint": "^8.20.0",
-    "tsconfig": "*",
     "typescript": "^4.7.4"
   },
   "dependencies": {}

--- a/packages/context/src/LaunchContext/LaunchContext.tsx
+++ b/packages/context/src/LaunchContext/LaunchContext.tsx
@@ -1,4 +1,4 @@
-import { Maybe, RoleType } from "@graphql/eden/generated";
+import { Maybe, RoleType } from "@eden/package-graphql/generated";
 import { createContext, Dispatch } from "react";
 
 export interface LaunchContextType {

--- a/packages/context/src/LaunchContext/LaunchProvider.tsx
+++ b/packages/context/src/LaunchContext/LaunchProvider.tsx
@@ -1,4 +1,4 @@
-import { Maybe, RoleType } from "@graphql/eden/generated";
+import { Maybe, RoleType } from "@eden/package-graphql/generated";
 import React, { useState } from "react";
 
 import { LaunchContext } from "./LaunchContext";

--- a/packages/context/src/LaunchProjectContext/LaunchProjectContext.tsx
+++ b/packages/context/src/LaunchProjectContext/LaunchProjectContext.tsx
@@ -1,4 +1,4 @@
-import { Project, RoleType } from "@graphql/eden/generated";
+import { Project, RoleType } from "@eden/package-graphql/generated";
 import { createContext } from "react";
 
 import { LaunchProjectModal, ProjectAction } from "./LaunchProjectProvider";

--- a/packages/context/src/LaunchProjectContext/LaunchProjectProvider.tsx
+++ b/packages/context/src/LaunchProjectContext/LaunchProjectProvider.tsx
@@ -1,4 +1,4 @@
-import { Project, RoleType } from "@graphql/eden/generated";
+import { Project, RoleType } from "@eden/package-graphql/generated";
 import React, { useReducer, useState } from "react";
 
 import { LaunchProjectContext } from "./LaunchProjectContext";
@@ -92,8 +92,9 @@ export const LaunchProjectProvider = ({
   const [openModal, setOpenModal] = useState<LaunchProjectModal | null>(null);
   const [selectedRole, setSelectedRole] = useState<RoleType | null>(null);
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
-  const [selectedMemberPercentage, setSelectedMemberPercentage] =
-    useState<number | null>(null);
+  const [selectedMemberPercentage, setSelectedMemberPercentage] = useState<
+    number | null
+  >(null);
   const [matchMembersPage, setMatchMembersPage] = useState<number>(0);
 
   const injectContext = {

--- a/packages/context/src/SignUpContext/SignUpProvider.tsx
+++ b/packages/context/src/SignUpContext/SignUpProvider.tsx
@@ -1,4 +1,4 @@
-import { UserContext } from "@context/eden";
+import { UserContext } from "@eden/package-context";
 import React, { useContext, useState } from "react";
 
 import { SignUpContext } from "./SignUpContext";

--- a/packages/context/src/UserContext/UserContext.tsx
+++ b/packages/context/src/UserContext/UserContext.tsx
@@ -1,4 +1,4 @@
-import { Members } from "@graphql/eden/generated";
+import { Members } from "@eden/package-graphql/generated";
 import { createContext, Dispatch } from "react";
 
 type userProfile = Members;

--- a/packages/context/src/UserContext/UserProvider.tsx
+++ b/packages/context/src/UserContext/UserProvider.tsx
@@ -1,6 +1,6 @@
 import { gql, useMutation, useQuery, useSubscription } from "@apollo/client";
-import { FIND_MEMBER_FULL, MEMBER_SUBSCRIPTION } from "@graphql/eden";
-import { Members, Mutation } from "@graphql/eden/generated";
+import { FIND_MEMBER_FULL, MEMBER_SUBSCRIPTION } from "@eden/package-graphql";
+import { Members, Mutation } from "@eden/package-graphql/generated";
 import { useSession } from "next-auth/react";
 import React, { useEffect, useState } from "react";
 

--- a/packages/context/tsconfig.json
+++ b/packages/context/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/react-library.json",
+  "extends": "@eden/package-tsconfig/react-library.json",
   "include": [".", "../config/jest/setup.ts"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@graphql/eden",
+  "name": "@eden/package-graphql",
   "version": "0.0.0",
   "main": "index.ts",
   "license": "MIT",
@@ -17,6 +17,7 @@
     "graphql-ws": "^5.10.1"
   },
   "devDependencies": {
+    "@eden/package-tsconfig": "*",
     "@graphql-codegen/cli": "^2.11.6",
     "@graphql-codegen/fragment-matcher": "^3.3.1",
     "@graphql-codegen/typescript": "^2.7.3",
@@ -25,7 +26,6 @@
     "cross-fetch": "^3.1.5",
     "eslint": "^8.8.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0",
-    "tsconfig": "*"
+    "eslint-plugin-simple-import-sort": "^7.0.0"
   }
 }

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/nextjs.json",
+  "extends": "@eden/package-tsconfig/nextjs.json",
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tsconfig",
+  "name": "@eden/package-tsconfig",
   "version": "0.0.0",
   "private": true,
   "main": "index.js",

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -1,1 +1,1 @@
-module.exports = require("config/.eslintrc");
+module.exports = require("@eden/package-config/.eslintrc");

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,16 +11,17 @@
     "clean-windows": "rd /s /q node_modules"
   },
   "devDependencies": {
-    "@context/eden": "*",
+    "@eden/package-config": "*",
+    "@eden/package-context": "*",
+    "@eden/package-graphql": "*",
+    "@eden/package-tsconfig": "*",
     "@faker-js/faker": "^7.4.0",
-    "@graphql/eden": "*",
     "@headlessui/react": "^1.6.6",
     "@heroicons/react": "^1.0.6",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
     "chart.js": "^3.9.1",
     "clsx": "^1.2.1",
-    "config": "*",
     "emoji-picker-react": "^3.6.1",
     "eslint": "^8.20.0",
     "identity-obj-proxy": "^3.0.0",
@@ -28,7 +29,6 @@
     "react-confetti": "^6.1.0",
     "react-multi-date-picker": "^3.3.0",
     "react-tooltip": "^4.2.21",
-    "tsconfig": "*",
     "typescript": "^4.8.4"
   },
   "dependencies": {}

--- a/packages/ui/src/cards/CandidateProfileCard/CandidateProfileCard.tsx
+++ b/packages/ui/src/cards/CandidateProfileCard/CandidateProfileCard.tsx
@@ -1,4 +1,4 @@
-import { Maybe, Members } from "@graphql/eden/generated";
+import { Maybe, Members } from "@eden/package-graphql/generated";
 import { XIcon } from "@heroicons/react/outline";
 import { Card, MatchAvatar } from "ui";
 

--- a/packages/ui/src/cards/EditProfileOnboardPartyCard/EditProfileOnboardPartyCard.tsx
+++ b/packages/ui/src/cards/EditProfileOnboardPartyCard/EditProfileOnboardPartyCard.tsx
@@ -1,7 +1,11 @@
 /* eslint-disable camelcase */
 import { useQuery } from "@apollo/client";
-import { FIND_ROLE_TEMPLATES } from "@graphql/eden";
-import { Maybe, Members, SkillType_Member } from "@graphql/eden/generated";
+import { FIND_ROLE_TEMPLATES } from "@eden/package-graphql";
+import {
+  Maybe,
+  Members,
+  SkillType_Member,
+} from "@eden/package-graphql/generated";
 import {
   Avatar,
   Card,

--- a/packages/ui/src/cards/MemberMatchCard/MemberMatchCard.tsx
+++ b/packages/ui/src/cards/MemberMatchCard/MemberMatchCard.tsx
@@ -4,7 +4,7 @@ import {
   Members,
   SkillRoleType,
   SkillType_Member,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import {
   Button,
   Card,

--- a/packages/ui/src/cards/MemberProfileCard/MemberProfileCard.tsx
+++ b/packages/ui/src/cards/MemberProfileCard/MemberProfileCard.tsx
@@ -1,4 +1,4 @@
-import { Members } from "@graphql/eden/generated";
+import { Members } from "@eden/package-graphql/generated";
 import { ChevronLeftIcon } from "@heroicons/react/outline";
 import { CheckCircleIcon } from "@heroicons/react/solid";
 import {

--- a/packages/ui/src/cards/ProjectSkillFilterCard/ProjectSkillFilterCard.tsx
+++ b/packages/ui/src/cards/ProjectSkillFilterCard/ProjectSkillFilterCard.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useState } from "react";
+/* eslint-disable camelcase */
+import { Maybe, SkillType_Member } from "@eden/package-graphql/generated";
+import React from "react";
 import {
-  TextField,
-  SwitchButton,
   Card,
   SearchSkill,
   SkillVisualisationComp,
+  SwitchButton,
+  TextField,
 } from "ui";
-import { Maybe, SkillType_Member } from "@graphql/eden/generated";
 const levels = [
   {
     title: "learning",

--- a/packages/ui/src/cards/RoleCard/RoleCard.tsx
+++ b/packages/ui/src/cards/RoleCard/RoleCard.tsx
@@ -1,4 +1,4 @@
-import { Maybe, RoleType } from "@graphql/eden/generated";
+import { Maybe, RoleType } from "@eden/package-graphql/generated";
 import { BsDot } from "react-icons/bs";
 import { MdArrowForward } from "react-icons/md";
 import { Badge, Card } from "ui";

--- a/packages/ui/src/cards/RoleSmallCard/RoleSmallCard.tsx
+++ b/packages/ui/src/cards/RoleSmallCard/RoleSmallCard.tsx
@@ -1,5 +1,9 @@
 /* eslint-disable camelcase */
-import { Maybe, RoleType, SkillRoleType } from "@graphql/eden/generated";
+import {
+  Maybe,
+  RoleType,
+  SkillRoleType,
+} from "@eden/package-graphql/generated";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline";
 import { PencilIcon } from "@heroicons/react/solid";
 import React, { useState } from "react";

--- a/packages/ui/src/cards/SignUpCard/SignUpCard.tsx
+++ b/packages/ui/src/cards/SignUpCard/SignUpCard.tsx
@@ -1,14 +1,14 @@
 // TODO: needs a test file
 /* eslint-disable camelcase */
 import { useMutation } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { UPDATE_MEMBER } from "@graphql/eden";
+import { UserContext } from "@eden/package-context";
+import { UPDATE_MEMBER } from "@eden/package-graphql";
 import {
   Maybe,
   Mutation,
   RoleTemplate,
   SkillType_Member,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { useContext, useEffect, useState } from "react";
 import { BsArrowRight } from "react-icons/bs";
 import {

--- a/packages/ui/src/cards/SkillsCard/SkillsCard.tsx
+++ b/packages/ui/src/cards/SkillsCard/SkillsCard.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { Maybe, SkillType_Member } from "@graphql/eden/generated";
+import { Maybe, SkillType_Member } from "@eden/package-graphql/generated";
 import React, { useEffect, useState } from "react";
 import { Badge, Card } from "ui";
 

--- a/packages/ui/src/cards/TopicCard/TopicCard.tsx
+++ b/packages/ui/src/cards/TopicCard/TopicCard.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { Card, TextHeading2, TextBody } from "ui";
+import { Card, TextBody, TextHeading2 } from "ui";
 
 // export interface TopicCardProps {
 
@@ -14,23 +13,21 @@ export const TopicCard = ({}) => {
           </TextHeading2>
           <hr className="w-50 h-[4px] pb-6"></hr>
         </div>
-        <TextBody>
-          <div className="pb-4">
-            <p>🗼 $CODE estimated value is $0.3014 </p>
-          </div>
-          <div>
-            <p>
-              🧠 Core team has recieved allocations of 1000 $CODE each. To vote
-              on the proposals you now have to hold at least 400 $CODE apart
-              from the NFT. Also, by buying 400 tokens you now are able to buy
-              your way into the DAO. What do you think about it? Share your
-              thoughts. Ut enim ad minim veniam, quis nostrud exercitation
-              ullamco laboris nisi ut aliquip ex ea commodo consequat.Volutpat
-              commodo sed egestas egestas fringilla. Viverra orci sagittis eu
-              volutpat odio. Viverra orci sagittis eu volutpat odio.
-            </p>
-          </div>
-        </TextBody>
+        <div className="pb-4">
+          <TextBody>🗼 $CODE estimated value is $0.3014 </TextBody>
+        </div>
+        <div>
+          <TextBody>
+            🧠 Core team has recieved allocations of 1000 $CODE each. To vote on
+            the proposals you now have to hold at least 400 $CODE apart from the
+            NFT. Also, by buying 400 tokens you now are able to buy your way
+            into the DAO. What do you think about it? Share your thoughts. Ut
+            enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi
+            ut aliquip ex ea commodo consequat.Volutpat commodo sed egestas
+            egestas fringilla. Viverra orci sagittis eu volutpat odio. Viverra
+            orci sagittis eu volutpat odio.
+          </TextBody>
+        </div>
       </div>
     </Card>
   );

--- a/packages/ui/src/cards/project/ProjectAboutCard/ProjectAboutCard.tsx
+++ b/packages/ui/src/cards/project/ProjectAboutCard/ProjectAboutCard.tsx
@@ -1,4 +1,4 @@
-import { Members, Project } from "@graphql/eden/generated";
+import { Members, Project } from "@eden/package-graphql/generated";
 import { useRouter } from "next/router";
 import { Card, ProjectChampion, ReadMore } from "ui";
 export interface ProjectAboutCardProps {

--- a/packages/ui/src/cards/project/ProjectCard/ProjectCard.tsx
+++ b/packages/ui/src/cards/project/ProjectCard/ProjectCard.tsx
@@ -1,6 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { Mutation, Project } from "@graphql/eden/generated";
+import { UserContext } from "@eden/package-context";
+import { Mutation, Project } from "@eden/package-graphql/generated";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 import { BsArrowRight } from "react-icons/bs";

--- a/packages/ui/src/cards/project/ProjectCardSmall/ProjectCardSmall.tsx
+++ b/packages/ui/src/cards/project/ProjectCardSmall/ProjectCardSmall.tsx
@@ -1,4 +1,4 @@
-import { Project } from "@graphql/eden/generated";
+import { Project } from "@eden/package-graphql/generated";
 import { Avatar, Card, ProgressBar } from "ui";
 
 export interface ProjectCardSmallProps {

--- a/packages/ui/src/cards/project/ProjectLayoutCard/ProjectLayoutCard.tsx
+++ b/packages/ui/src/cards/project/ProjectLayoutCard/ProjectLayoutCard.tsx
@@ -1,4 +1,4 @@
-import { Maybe, Project, RoleType } from "@graphql/eden/generated";
+import { Maybe, Project, RoleType } from "@eden/package-graphql/generated";
 import { Card, EmojiSelector, RoleList, TextBody, TextHeading3 } from "ui";
 
 export interface ProjectLayoutCardProps {

--- a/packages/ui/src/cards/project/ProjectMatchCard/ProjectMatchCard.tsx
+++ b/packages/ui/src/cards/project/ProjectMatchCard/ProjectMatchCard.tsx
@@ -2,7 +2,7 @@ import {
   MatchSkillsToProjectsOutput,
   Maybe,
   Members,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { Avatar, Badge, Button, Card, ProjectChampion, TextHeading3 } from "ui";
 
 export interface IProjectMatchCardProps {

--- a/packages/ui/src/cards/project/ProjectRecommendedCard/ProjectRecommendedCard.tsx
+++ b/packages/ui/src/cards/project/ProjectRecommendedCard/ProjectRecommendedCard.tsx
@@ -1,6 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { Maybe, Mutation, Project } from "@graphql/eden/generated";
+import { UserContext } from "@eden/package-context";
+import { Maybe, Mutation, Project } from "@eden/package-graphql/generated";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 import { Avatar, Card, Favorite } from "ui";

--- a/packages/ui/src/cards/project/ProjectStatusCard/ProjectStatusCard.tsx
+++ b/packages/ui/src/cards/project/ProjectStatusCard/ProjectStatusCard.tsx
@@ -1,4 +1,4 @@
-import { Project } from "@graphql/eden/generated";
+import { Project } from "@eden/package-graphql/generated";
 import { useState } from "react";
 import { BsArrowRight } from "react-icons/bs";
 import {

--- a/packages/ui/src/cards/user/UserCard/UserCard.tsx
+++ b/packages/ui/src/cards/user/UserCard/UserCard.tsx
@@ -1,5 +1,5 @@
 import { gql, useMutation } from "@apollo/client";
-import { Maybe, Members } from "@graphql/eden/generated";
+import { Maybe, Members } from "@eden/package-graphql/generated";
 import { useState } from "react";
 import { Avatar, Badge, Button, Card } from "ui";
 

--- a/packages/ui/src/cards/user/UserCardOnboardParty/UserCardOnboardParty.tsx
+++ b/packages/ui/src/cards/user/UserCardOnboardParty/UserCardOnboardParty.tsx
@@ -1,5 +1,9 @@
 /* eslint-disable camelcase */
-import { Maybe, Members, SkillType_Member } from "@graphql/eden/generated";
+import {
+  Maybe,
+  Members,
+  SkillType_Member,
+} from "@eden/package-graphql/generated";
 import {
   Avatar,
   Card,

--- a/packages/ui/src/cards/user/UserExperienceCard/UserExperienceCard.tsx
+++ b/packages/ui/src/cards/user/UserExperienceCard/UserExperienceCard.tsx
@@ -1,4 +1,4 @@
-import { PreviusProjectsInput } from "@graphql/eden/generated";
+import { PreviusProjectsInput } from "@eden/package-graphql/generated";
 import { useReducer } from "react";
 import { Button, Calendar, Card, TextArea, TextField } from "ui";
 

--- a/packages/ui/src/cards/user/UserInformationCard/UserInformationCard.tsx
+++ b/packages/ui/src/cards/user/UserInformationCard/UserInformationCard.tsx
@@ -1,4 +1,4 @@
-import { Maybe, PreviusProjectsType } from "@graphql/eden/generated";
+import { Maybe, PreviusProjectsType } from "@eden/package-graphql/generated";
 import { useState } from "react";
 import { FiEdit3 } from "react-icons/fi";
 import { IoIosExpand } from "react-icons/io";

--- a/packages/ui/src/cards/user/UserProfileCard/UserProfileCard.tsx
+++ b/packages/ui/src/cards/user/UserProfileCard/UserProfileCard.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
-import { UserContext } from "@context/eden";
-import { Maybe, SkillType_Member } from "@graphql/eden/generated";
+import { UserContext } from "@eden/package-context";
+import { Maybe, SkillType_Member } from "@eden/package-graphql/generated";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline";
 import { useContext, useState } from "react";
 import { Avatar, NumberCircle, SkillList, TextLabel } from "ui";

--- a/packages/ui/src/components/Expandable/Expandable.test.tsx
+++ b/packages/ui/src/components/Expandable/Expandable.test.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider } from "@apollo/client/testing";
-import { FIND_SKILL_BY_CATEGORIES } from "@graphql/eden";
+import { FIND_SKILL_BY_CATEGORIES } from "@eden/package-graphql";
 import { render } from "@testing-library/react";
 
 import { Expandable } from ".";

--- a/packages/ui/src/components/Expandable/Expandable.tsx
+++ b/packages/ui/src/components/Expandable/Expandable.tsx
@@ -1,7 +1,11 @@
+/* eslint-disable camelcase */
 import { useQuery } from "@apollo/client";
-import { FIND_SKILL_BY_CATEGORIES } from "@graphql/eden";
-// eslint-disable-next-line camelcase
-import { Maybe, Skills, SkillType_Member } from "@graphql/eden/generated";
+import { FIND_SKILL_BY_CATEGORIES } from "@eden/package-graphql";
+import {
+  Maybe,
+  Skills,
+  SkillType_Member,
+} from "@eden/package-graphql/generated";
 import { CheckCircleIcon } from "@heroicons/react/solid";
 import { useState } from "react";
 import { Button } from "ui";
@@ -13,7 +17,6 @@ type LevelProp = {
 
 type ExpandableProps = {
   category: string;
-  // eslint-disable-next-line camelcase
   skills?: Maybe<SkillType_Member>[];
   allSkills?: Skills[];
   isOpen?: boolean;

--- a/packages/ui/src/components/LoginButton/LoginButton.test.tsx
+++ b/packages/ui/src/components/LoginButton/LoginButton.test.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider } from "@apollo/client/testing";
-import { FIND_MEMBER } from "@graphql/eden";
+import { FIND_MEMBER } from "@eden/package-graphql";
 import { render } from "@testing-library/react";
 import { SessionProvider } from "next-auth/react";
 

--- a/packages/ui/src/components/LoginButton/LoginButton.tsx
+++ b/packages/ui/src/components/LoginButton/LoginButton.tsx
@@ -1,4 +1,4 @@
-import { UserContext } from "@context/eden";
+import { UserContext } from "@eden/package-context";
 import { Menu, Transition } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/solid";
 import { useRouter } from "next/router";

--- a/packages/ui/src/components/ProjectChampion/ProjectChampion.tsx
+++ b/packages/ui/src/components/ProjectChampion/ProjectChampion.tsx
@@ -1,6 +1,6 @@
 import "./style.css";
 
-import { Members } from "@graphql/eden/generated";
+import { Members } from "@eden/package-graphql/generated";
 import { Avatar } from "ui";
 
 export interface IProjectChampion {

--- a/packages/ui/src/components/ProjectInfo/ProjectInfo.tsx
+++ b/packages/ui/src/components/ProjectInfo/ProjectInfo.tsx
@@ -1,4 +1,4 @@
-import { Project } from "@graphql/eden/generated";
+import { Project } from "@eden/package-graphql/generated";
 import HeartIcon from "@heroicons/react/outline/HeartIcon";
 import { BsArrowRight } from "react-icons/bs";
 import { Avatar, Button } from "ui";

--- a/packages/ui/src/components/RoleList/RoleList.tsx
+++ b/packages/ui/src/components/RoleList/RoleList.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { Maybe, RoleType, TeamType } from "@graphql/eden/generated";
+import { Maybe, RoleType, TeamType } from "@eden/package-graphql/generated";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline";
 import React, { useState } from "react";
 import { AvatarProps, Button, RoleSmallCard, TextBody } from "ui";

--- a/packages/ui/src/components/SearchSkill/SearchSkill.stories.tsx
+++ b/packages/ui/src/components/SearchSkill/SearchSkill.stories.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider } from "@apollo/client/testing";
-import { FIND_ALL_CATEGORIES } from "@graphql/eden";
+import { FIND_ALL_CATEGORIES } from "@eden/package-graphql";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { useState } from "react";
 

--- a/packages/ui/src/components/SearchSkill/SearchSkill.tsx
+++ b/packages/ui/src/components/SearchSkill/SearchSkill.tsx
@@ -1,9 +1,12 @@
 // TODO: Create a test file for this component //
 
 import { useQuery } from "@apollo/client";
-import { FIND_ALL_CATEGORIES, SKILLS_AUTOCOMPLETE } from "@graphql/eden";
+import {
+  FIND_ALL_CATEGORIES,
+  SKILLS_AUTOCOMPLETE,
+} from "@eden/package-graphql";
 // eslint-disable-next-line camelcase
-import { Maybe, SkillType_Member } from "@graphql/eden/generated";
+import { Maybe, SkillType_Member } from "@eden/package-graphql/generated";
 import { Combobox } from "@headlessui/react";
 import { EmojiSadIcon } from "@heroicons/react/outline";
 import { SearchIcon } from "@heroicons/react/solid";

--- a/packages/ui/src/components/SkillList/SkillList.tsx
+++ b/packages/ui/src/components/SkillList/SkillList.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { Maybe, SkillType_Member } from "@graphql/eden/generated";
+import { Maybe, SkillType_Member } from "@eden/package-graphql/generated";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline";
 import React, { useState } from "react";
 import { Badge } from "ui";

--- a/packages/ui/src/components/SkillVisualisationComp/SkillVisualisationComp.tsx
+++ b/packages/ui/src/components/SkillVisualisationComp/SkillVisualisationComp.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import { Maybe, SkillType_Member } from "@graphql/eden/generated";
+import { Maybe, SkillType_Member } from "@eden/package-graphql/generated";
 // import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline";
 import React, { useState } from "react";
 import { CheckBox, SkillList } from "ui";

--- a/packages/ui/src/components/SocialMediaComponent/SocialMediaComp.tsx
+++ b/packages/ui/src/components/SocialMediaComponent/SocialMediaComp.tsx
@@ -1,4 +1,4 @@
-import { LinkType, Maybe } from "@graphql/eden/generated";
+import { LinkType, Maybe } from "@eden/package-graphql/generated";
 import { useEffect, useState } from "react";
 import {
   FaDiscord,

--- a/packages/ui/src/components/TeamAttributeChart/TeamAttributeChart.tsx
+++ b/packages/ui/src/components/TeamAttributeChart/TeamAttributeChart.tsx
@@ -1,4 +1,4 @@
-import { AttributesType } from "@graphql/eden/generated";
+import { AttributesType } from "@eden/package-graphql/generated";
 import {
   Chart as ChartJS,
   Filler,

--- a/packages/ui/src/components/UserProfileMenu/UserProfileMenu.tsx
+++ b/packages/ui/src/components/UserProfileMenu/UserProfileMenu.tsx
@@ -1,4 +1,4 @@
-import { UserContext } from "@context/eden";
+import { UserContext } from "@eden/package-context";
 import { useRouter } from "next/router";
 import { useContext } from "react";
 import { MdCreateNewFolder, MdFactCheck, MdPeopleAlt } from "react-icons/md";

--- a/packages/ui/src/containers/ApplyByRoleContainer/ApplyByRoleContainer.tsx
+++ b/packages/ui/src/containers/ApplyByRoleContainer/ApplyByRoleContainer.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable camelcase */
 import { gql, useMutation } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { UPDATE_MEMBER } from "@graphql/eden";
+import { UserContext } from "@eden/package-context";
+import { UPDATE_MEMBER } from "@eden/package-graphql";
 import {
   MatchSkillsToProjectsOutput,
   Maybe,
   Members,
   Mutation,
   Project,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
 import { FaGithub, FaTelegram, FaTwitter } from "react-icons/fa";

--- a/packages/ui/src/containers/ApplyContainer/ApplyContainer.tsx
+++ b/packages/ui/src/containers/ApplyContainer/ApplyContainer.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unescaped-entities */
 import { gql, useMutation } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { Project } from "@graphql/eden/generated";
+import { UserContext } from "@eden/package-context";
+import { Project } from "@eden/package-graphql/generated";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";

--- a/packages/ui/src/containers/ChampionContainer/ChampionContainer.tsx
+++ b/packages/ui/src/containers/ChampionContainer/ChampionContainer.tsx
@@ -1,4 +1,4 @@
-import { Members, Project } from "@graphql/eden/generated";
+import { Members, Project } from "@eden/package-graphql/generated";
 import { useState } from "react";
 import { TabsSelector, UserCard, UserWithDescription } from "ui";
 

--- a/packages/ui/src/containers/ChampionRecruitContainer/ChampionRecruitContainer.tsx
+++ b/packages/ui/src/containers/ChampionRecruitContainer/ChampionRecruitContainer.tsx
@@ -1,5 +1,5 @@
 import { gql, useMutation } from "@apollo/client";
-import { Members, Project, TeamType } from "@graphql/eden/generated";
+import { Members, Project, TeamType } from "@eden/package-graphql/generated";
 import { useEffect, useState } from "react";
 import {
   AvailabilityComp,

--- a/packages/ui/src/containers/InviteContainer/InviteContainer.tsx
+++ b/packages/ui/src/containers/InviteContainer/InviteContainer.tsx
@@ -1,6 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { Project } from "@graphql/eden/generated";
+import { UserContext } from "@eden/package-context";
+import { Project } from "@eden/package-graphql/generated";
 // import Link from "next/link";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";

--- a/packages/ui/src/containers/LaunchContainer/LaunchContainer.stories.tsx
+++ b/packages/ui/src/containers/LaunchContainer/LaunchContainer.stories.tsx
@@ -1,4 +1,4 @@
-import { LaunchProvider } from "@context/eden";
+import { LaunchProvider } from "@eden/package-context";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { LaunchContainer } from "./LaunchContainer";

--- a/packages/ui/src/containers/LaunchContainer/LaunchContainer.tsx
+++ b/packages/ui/src/containers/LaunchContainer/LaunchContainer.tsx
@@ -1,6 +1,11 @@
 import { gql, useMutation } from "@apollo/client";
-import { LaunchContext, UserContext } from "@context/eden";
-import { Maybe, Mutation, Role, ServerTemplate } from "@graphql/eden/generated";
+import { LaunchContext, UserContext } from "@eden/package-context";
+import {
+  Maybe,
+  Mutation,
+  Role,
+  ServerTemplate,
+} from "@eden/package-graphql/generated";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 import { BsArrowLeft, BsArrowRight } from "react-icons/bs";

--- a/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewBudget.tsx
+++ b/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewBudget.tsx
@@ -1,6 +1,6 @@
-import { LaunchContext } from "@context/eden";
+import { LaunchContext } from "@eden/package-context";
 import { useContext } from "react";
-import { TextArea, TextField, Calendar } from "ui";
+import { Calendar, TextArea, TextField } from "ui";
 
 export const LaunchViewBudget = () => {
   const { projectDescription, setProjectDescription } =

--- a/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewDescribe.tsx
+++ b/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewDescribe.tsx
@@ -1,4 +1,4 @@
-import { LaunchContext } from "@context/eden";
+import { LaunchContext } from "@eden/package-context";
 import { useContext } from "react";
 import { TextArea } from "ui";
 

--- a/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewLinks.tsx
+++ b/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewLinks.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unescaped-entities */
-import { LaunchContext } from "@context/eden";
-import { ServerTemplate } from "@graphql/eden/generated";
+import { LaunchContext } from "@eden/package-context";
+import { ServerTemplate } from "@eden/package-graphql/generated";
 import { useContext } from "react";
 import {
   FaDiscord,

--- a/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewName.tsx
+++ b/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewName.tsx
@@ -1,4 +1,4 @@
-import { LaunchContext } from "@context/eden";
+import { LaunchContext } from "@eden/package-context";
 import { useContext } from "react";
 import { TextField } from "ui";
 

--- a/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewRoles.tsx
+++ b/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewRoles.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable camelcase */
-import { LaunchContext } from "@context/eden";
+import { LaunchContext } from "@eden/package-context";
 import {
   Maybe,
   Role,
   RoleType,
   SkillType_Member,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { useContext, useState } from "react";
 import { Button, Card, Dropdown, Modal, SearchSkill, SkillsCard } from "ui";
 

--- a/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewVerify.tsx
+++ b/packages/ui/src/containers/LaunchContainer/LaunchViews/LaunchViewVerify.tsx
@@ -1,4 +1,4 @@
-import { LaunchContext } from "@context/eden";
+import { LaunchContext } from "@eden/package-context";
 import { useContext } from "react";
 import { BioComponent, SocialMediaComp } from "ui";
 

--- a/packages/ui/src/containers/LaunchProjectContainer/LaunchProjectContainer.tsx
+++ b/packages/ui/src/containers/LaunchProjectContainer/LaunchProjectContainer.tsx
@@ -1,4 +1,4 @@
-import { LaunchProjectContext, ProjectActionKind } from "@context/eden";
+import { LaunchProjectContext, ProjectActionKind } from "@eden/package-context";
 import { useRouter } from "next/router";
 import { useContext } from "react";
 import {

--- a/packages/ui/src/containers/OnboardPartyContainer/OnboardPartyContainer.tsx
+++ b/packages/ui/src/containers/OnboardPartyContainer/OnboardPartyContainer.tsx
@@ -1,4 +1,4 @@
-import { Members } from "@graphql/eden/generated";
+import { Members } from "@eden/package-graphql/generated";
 import { Card, TextHeading3, UserCardOnboardParty } from "ui";
 
 import { getUserProgress } from "../../../utils/user-progress";

--- a/packages/ui/src/containers/ProfileContainer/ProfileContainer.tsx
+++ b/packages/ui/src/containers/ProfileContainer/ProfileContainer.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
-import { UserContext } from "@context/eden";
-import { Maybe, SkillType_Member } from "@graphql/eden/generated";
+import { UserContext } from "@eden/package-context";
+import { Maybe, SkillType_Member } from "@eden/package-graphql/generated";
 import { useContext, useState } from "react";
 import { AiOutlineCheck } from "react-icons/ai";
 import {

--- a/packages/ui/src/containers/ShortlistContainer/ShortlistContainer.tsx
+++ b/packages/ui/src/containers/ShortlistContainer/ShortlistContainer.tsx
@@ -1,4 +1,7 @@
-import { LaunchProjectContext, LaunchProjectModal } from "@context/eden";
+import {
+  LaunchProjectContext,
+  LaunchProjectModal,
+} from "@eden/package-context";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/outline";
 import { useContext } from "react";
 import {

--- a/packages/ui/src/containers/ShortlistMemberContainer/ShortlistMemberContainer.tsx
+++ b/packages/ui/src/containers/ShortlistMemberContainer/ShortlistMemberContainer.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
-import { LaunchProjectContext, ProjectActionKind } from "@context/eden";
-import { FIND_MEMBER } from "@graphql/eden";
+import { LaunchProjectContext, ProjectActionKind } from "@eden/package-context";
+import { FIND_MEMBER } from "@eden/package-graphql";
 import { useContext } from "react";
 import { Loading, MemberProfileCard } from "ui";
 

--- a/packages/ui/src/containers/ShortlistModalContainer/ShortlistModalContainer.tsx
+++ b/packages/ui/src/containers/ShortlistModalContainer/ShortlistModalContainer.tsx
@@ -2,14 +2,14 @@ import {
   LaunchProjectContext,
   LaunchProjectModal,
   ProjectActionKind,
-} from "@context/eden";
+} from "@eden/package-context";
 import {
   Maybe,
   RoleTemplate,
   RoleType,
   SkillRoleType,
   Skills,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { useContext } from "react";
 import {
   CongratulationsModal,

--- a/packages/ui/src/containers/ShortlistSideContainer/ShortlistSideContainer.tsx
+++ b/packages/ui/src/containers/ShortlistSideContainer/ShortlistSideContainer.tsx
@@ -1,4 +1,7 @@
-import { LaunchProjectContext, LaunchProjectModal } from "@context/eden";
+import {
+  LaunchProjectContext,
+  LaunchProjectModal,
+} from "@eden/package-context";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/outline";
 import { useContext } from "react";
 import { CandidateProfileCard, Loading, ProjectLayoutCard } from "ui";

--- a/packages/ui/src/containers/SignUpContainer/SignUpContainer.stories.tsx
+++ b/packages/ui/src/containers/SignUpContainer/SignUpContainer.stories.tsx
@@ -1,4 +1,4 @@
-import { SignUpProvider } from "@context/eden";
+import { SignUpProvider } from "@eden/package-context";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { CurrentUserDecorator } from "storybook/.storybook/decorator";
 

--- a/packages/ui/src/containers/SignUpContainer/SignUpContainer.tsx
+++ b/packages/ui/src/containers/SignUpContainer/SignUpContainer.tsx
@@ -1,6 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
-import { SignUpContext, UserContext } from "@context/eden";
-import { Mutation } from "@graphql/eden/generated";
+import { SignUpContext, UserContext } from "@eden/package-context";
+import { Mutation } from "@eden/package-graphql/generated";
 import { useRouter } from "next/router";
 import { useContext, useState } from "react";
 import { BsArrowLeft, BsArrowRight } from "react-icons/bs";

--- a/packages/ui/src/containers/SignUpContainer/SignUpViews/SignUpViewBio.tsx
+++ b/packages/ui/src/containers/SignUpContainer/SignUpViews/SignUpViewBio.tsx
@@ -1,4 +1,4 @@
-import { SignUpContext, UserContext } from "@context/eden";
+import { SignUpContext, UserContext } from "@eden/package-context";
 import { useContext } from "react";
 import { Avatar, TextArea } from "ui";
 

--- a/packages/ui/src/containers/SignUpContainer/SignUpViews/SignUpViewConfirm.tsx
+++ b/packages/ui/src/containers/SignUpContainer/SignUpViews/SignUpViewConfirm.tsx
@@ -1,4 +1,4 @@
-import { SignUpContext, UserContext } from "@context/eden";
+import { SignUpContext, UserContext } from "@eden/package-context";
 import { useContext } from "react";
 import { Avatar, BioComponent, SocialMediaComp } from "ui";
 

--- a/packages/ui/src/containers/SignUpContainer/SignUpViews/SignUpViewShare.tsx
+++ b/packages/ui/src/containers/SignUpContainer/SignUpViews/SignUpViewShare.tsx
@@ -1,4 +1,4 @@
-import { SignUpContext } from "@context/eden";
+import { SignUpContext } from "@eden/package-context";
 import { useContext } from "react";
 import { TextArea } from "ui";
 

--- a/packages/ui/src/containers/SignUpContainer/SignUpViews/SignUpViewSocials.tsx
+++ b/packages/ui/src/containers/SignUpContainer/SignUpViews/SignUpViewSocials.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-unescaped-entities */
-import { SignUpContext } from "@context/eden";
+import { SignUpContext } from "@eden/package-context";
 import { useContext } from "react";
 import {
   // FaDiscord,

--- a/packages/ui/src/containers/SignUpContainerMain/SignUpContainerMain.tsx
+++ b/packages/ui/src/containers/SignUpContainerMain/SignUpContainerMain.tsx
@@ -3,7 +3,7 @@ import {
   Maybe,
   Project,
   RoleTemplate,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { ApplyByRoleContainer, ProjectMatchList, SignUpCard } from "ui";
 
 export interface ISignUpContainerMainProps {

--- a/packages/ui/src/containers/SignUpContainerSide/SignUpContainerSide.tsx
+++ b/packages/ui/src/containers/SignUpContainerSide/SignUpContainerSide.tsx
@@ -2,7 +2,7 @@ import {
   MatchSkillsToProjectsOutput,
   Maybe,
   Project,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { useState } from "react";
 import { Avatar, Card, UserProfileCard } from "ui";
 

--- a/packages/ui/src/elements/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/elements/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { Maybe } from "@graphql/eden/generated";
+import { Maybe } from "@eden/package-graphql/generated";
 import { Combobox } from "@headlessui/react";
 import { SelectorIcon } from "@heroicons/react/solid";
 import clsx from "clsx";
@@ -87,9 +87,9 @@ export const Dropdown = ({
 
         <Combobox.Options className="absolute z-40 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
           {filteredItems && filteredItems.length === 0 && query !== "" ? (
-            <div className="relative cursor-default select-none py-2 px-4 text-gray-700">
+            <span className="relative cursor-default select-none py-2 px-4 text-gray-700">
               Nothing found.
-            </div>
+            </span>
           ) : (
             filteredItems &&
             filteredItems?.map((item: IItems, index: number) => (

--- a/packages/ui/src/layout/AppHeader/AppHeader.test.tsx
+++ b/packages/ui/src/layout/AppHeader/AppHeader.test.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider } from "@apollo/client/testing";
-import { FIND_MEMBER } from "@graphql/eden";
+import { FIND_MEMBER } from "@eden/package-graphql";
 import { render } from "@testing-library/react";
 import { SessionProvider } from "next-auth/react";
 

--- a/packages/ui/src/layout/AppUserLayout/AppUserLayout.tsx
+++ b/packages/ui/src/layout/AppUserLayout/AppUserLayout.tsx
@@ -1,4 +1,4 @@
-// import { UserContext } from "@context/eden";
+// import { UserContext } from "@eden/package-context";
 import Head from "next/head";
 // import { useRouter } from "next/router";
 // import { useContext } from "react";

--- a/packages/ui/src/layout/AppUserMenuLayout/AppUserMenuLayout.tsx
+++ b/packages/ui/src/layout/AppUserMenuLayout/AppUserMenuLayout.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
-import { UserContext } from "@context/eden";
-import { FIND_PROJECTS_RECOMMENDED } from "@graphql/eden";
+import { UserContext } from "@eden/package-context";
+import { FIND_PROJECTS_RECOMMENDED } from "@eden/package-graphql";
 import Head from "next/head";
 // import { useRouter } from "next/router";
 import { useContext } from "react";

--- a/packages/ui/src/lists/CandidateSelectionList/CandidateSelectionList.tsx
+++ b/packages/ui/src/lists/CandidateSelectionList/CandidateSelectionList.tsx
@@ -3,7 +3,7 @@ import {
   MatchMembersToSkillOutput,
   Maybe,
   RoleTemplate,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { useEffect, useState } from "react";
 import { RoleCandidateSelector, UserCard } from "ui";
 

--- a/packages/ui/src/lists/ProjectList/ProjectList.tsx
+++ b/packages/ui/src/lists/ProjectList/ProjectList.tsx
@@ -1,4 +1,8 @@
-import { Maybe, Project, ProjectMemberType } from "@graphql/eden/generated";
+import {
+  Maybe,
+  Project,
+  ProjectMemberType,
+} from "@eden/package-graphql/generated";
 import { ProjectCard } from "ui";
 
 export interface ProjectListProps {

--- a/packages/ui/src/lists/ProjectMatchList/ProjectMatchList.tsx
+++ b/packages/ui/src/lists/ProjectMatchList/ProjectMatchList.tsx
@@ -1,5 +1,8 @@
-import { UserContext } from "@context/eden";
-import { MatchSkillsToProjectsOutput, Maybe } from "@graphql/eden/generated";
+import { UserContext } from "@eden/package-context";
+import {
+  MatchSkillsToProjectsOutput,
+  Maybe,
+} from "@eden/package-graphql/generated";
 import { useContext } from "react";
 import { Loading, ProjectMatchCard, TextHeading2 } from "ui";
 

--- a/packages/ui/src/lists/RecommendedList/RecommendedList.tsx
+++ b/packages/ui/src/lists/RecommendedList/RecommendedList.tsx
@@ -1,4 +1,4 @@
-import { Maybe, ProjectMatchType } from "@graphql/eden/generated";
+import { Maybe, ProjectMatchType } from "@eden/package-graphql/generated";
 import { ProjectRecommendedCard } from "ui";
 
 export interface RecommendedListProps {

--- a/packages/ui/src/lists/ShortlistList/ShortlistList.tsx
+++ b/packages/ui/src/lists/ShortlistList/ShortlistList.tsx
@@ -1,4 +1,4 @@
-import { Project } from "@graphql/eden/generated";
+import { Project } from "@eden/package-graphql/generated";
 import { UserCard } from "ui";
 
 export interface ShortlistListProps {

--- a/packages/ui/src/lists/SideNavProjectList/SideNavProjectList.stories.tsx
+++ b/packages/ui/src/lists/SideNavProjectList/SideNavProjectList.stories.tsx
@@ -1,5 +1,5 @@
+import { Maybe, ProjectMemberType } from "@eden/package-graphql/generated";
 import { faker } from "@faker-js/faker";
-import { Maybe, ProjectMemberType } from "@graphql/eden/generated";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { getProject } from "storybook/mocks";
 

--- a/packages/ui/src/lists/SideNavProjectList/SideNavProjectList.tsx
+++ b/packages/ui/src/lists/SideNavProjectList/SideNavProjectList.tsx
@@ -1,4 +1,4 @@
-import { Maybe, ProjectMemberType } from "@graphql/eden/generated";
+import { Maybe, ProjectMemberType } from "@eden/package-graphql/generated";
 import { useEffect, useState } from "react";
 import { ProjectCardSmall } from "ui";
 

--- a/packages/ui/src/modals/ProjectInfoModal/ProjectInfoModal.test.tsx
+++ b/packages/ui/src/modals/ProjectInfoModal/ProjectInfoModal.test.tsx
@@ -1,4 +1,4 @@
-import { Maybe, RoleTemplate } from "@graphql/eden/generated";
+import { Maybe, RoleTemplate } from "@eden/package-graphql/generated";
 
 import { render } from "../../../utils/jest-apollo";
 import { ProjectInfoModal } from ".";

--- a/packages/ui/src/modals/RoleModalContainer/RoleModal.test.tsx
+++ b/packages/ui/src/modals/RoleModalContainer/RoleModal.test.tsx
@@ -1,4 +1,4 @@
-import { Maybe, RoleTemplate } from "@graphql/eden/generated";
+import { Maybe, RoleTemplate } from "@eden/package-graphql/generated";
 
 import { render } from "../../../utils/jest-apollo";
 import { RoleModal } from ".";

--- a/packages/ui/src/modals/RoleModalContainer/RoleModal.tsx
+++ b/packages/ui/src/modals/RoleModalContainer/RoleModal.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
-import { FIND_ROLE_TEMPLATES } from "@graphql/eden";
-import { Maybe, RoleTemplate } from "@graphql/eden/generated";
+import { FIND_ROLE_TEMPLATES } from "@eden/package-graphql";
+import { Maybe, RoleTemplate } from "@eden/package-graphql/generated";
 import { useState } from "react";
 import { Button, Modal, RoleSelector } from "ui";
 
@@ -20,8 +20,9 @@ export const RoleModal = ({
   onSubmit,
   onRoleSelected,
 }: RoleModalProps) => {
-  const [selectedRole, setSelectedRole] =
-    useState<Maybe<RoleTemplate> | null>(null);
+  const [selectedRole, setSelectedRole] = useState<Maybe<RoleTemplate> | null>(
+    null
+  );
 
   const { data: roles } = useQuery(FIND_ROLE_TEMPLATES, {
     variables: {

--- a/packages/ui/src/modals/ShortlistMemeberModal/ShortlistMemberModal.tsx
+++ b/packages/ui/src/modals/ShortlistMemeberModal/ShortlistMemberModal.tsx
@@ -1,4 +1,4 @@
-import { Maybe, RoleType } from "@graphql/eden/generated";
+import { Maybe, RoleType } from "@eden/package-graphql/generated";
 import React from "react";
 import { Button, CandidateProfileCard, Modal, TextHeading2 } from "ui";
 

--- a/packages/ui/src/modals/SkillsModalContainer/SkillsModal.stories.tsx
+++ b/packages/ui/src/modals/SkillsModalContainer/SkillsModal.stories.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider } from "@apollo/client/testing";
-import { FIND_ALL_CATEGORIES } from "@graphql/eden";
+import { FIND_ALL_CATEGORIES } from "@eden/package-graphql";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { SkillsModal } from "./SkillsModal";

--- a/packages/ui/src/modals/SkillsModalContainer/SkillsModal.tsx
+++ b/packages/ui/src/modals/SkillsModalContainer/SkillsModal.tsx
@@ -3,7 +3,7 @@ import {
   Maybe,
   SkillRoleType,
   SkillType_Member,
-} from "@graphql/eden/generated";
+} from "@eden/package-graphql/generated";
 import { Button, Modal, SearchSkill, SkillList } from "ui";
 
 export interface ISkillsModalProps {

--- a/packages/ui/src/selectors/RoleCandidateSelector/RoleCandidateSelector.tsx
+++ b/packages/ui/src/selectors/RoleCandidateSelector/RoleCandidateSelector.tsx
@@ -1,4 +1,4 @@
-import { RoleTemplate } from "@graphql/eden/generated";
+import { RoleTemplate } from "@eden/package-graphql/generated";
 import { useEffect, useState } from "react";
 import { AiOutlineDoubleLeft, AiOutlineDoubleRight } from "react-icons/ai";
 

--- a/packages/ui/src/selectors/RoleSelector/RoleSelector.tsx
+++ b/packages/ui/src/selectors/RoleSelector/RoleSelector.tsx
@@ -1,4 +1,4 @@
-import { Maybe, RoleTemplate } from "@graphql/eden/generated";
+import { Maybe, RoleTemplate } from "@eden/package-graphql/generated";
 import { Combobox } from "@headlessui/react";
 import { ChevronDownIcon } from "@heroicons/react/solid";
 import { useState } from "react";

--- a/packages/ui/src/selectors/SkillSelector/SkillSelector.tsx
+++ b/packages/ui/src/selectors/SkillSelector/SkillSelector.tsx
@@ -1,4 +1,4 @@
-import { Skills } from "@graphql/eden/generated";
+import { Skills } from "@eden/package-graphql/generated";
 import { XIcon } from "@heroicons/react/outline";
 import { useEffect, useState } from "react";
 import { Dropdown } from "ui";

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -1,3 +1,3 @@
-const config = require("config/tailwind.config.js");
+const config = require("@eden/package-config/tailwind.config.js");
 
 module.exports = config;

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig/react-library.json",
+  "extends": "@eden/package-tsconfig/react-library.json",
   "include": [".", "../config/jest/setup.ts"],
   "exclude": ["dist", "build", "node_modules"]
 }

--- a/packages/ui/utils/jest-apollo.tsx
+++ b/packages/ui/utils/jest-apollo.tsx
@@ -1,5 +1,5 @@
 import { ApolloProvider } from "@apollo/client";
-import { apolloClient } from "@graphql/eden";
+import { apolloClient } from "@eden/package-graphql";
 import { render, RenderOptions } from "@testing-library/react";
 import React, { FC, ReactElement } from "react";
 

--- a/packages/ui/utils/user-progress.tsx
+++ b/packages/ui/utils/user-progress.tsx
@@ -1,4 +1,4 @@
-import { Members } from "@graphql/eden/generated";
+import { Members } from "@eden/package-graphql/generated";
 
 export const getUserProgress = (user: Members) => {
   let progress = 0;


### PR DESCRIPTION
cleans up naming for internal eden packages.

this is the first round covering all packages except for the ui package