### PR TITLE
Eden Frontend Discord API -- Fetch Mutual Guilds

### DIFF
--- a/apps/alpha/pages/api/auth/[...nextauth].js
+++ b/apps/alpha/pages/api/auth/[...nextauth].js
@@ -7,7 +7,7 @@ export default NextAuth({
       clientId: process.env.DISCORD_CLIENT_ID,
       clientSecret: process.env.DISCORD_CLIENT_SECRET,
       secret: process.env.NEXT_PUBLIC_SECRET,
-      // authorization: { params: { scope: scopes } },
+      authorization: { params: { scope: "identify email guilds" } },
     }),
   ],
   secret: process.env.NEXT_PUBLIC_SECRET,
@@ -19,10 +19,14 @@ export default NextAuth({
       if (session?.user) {
         session.user.id = token.uid;
       }
-
+      session.accessToken = token.accessToken;
       return session;
     },
-    jwt: async ({ user, token }) => {
+    jwt: async ({ user, token, account }) => {
+      if (account) {
+        token.accessToken = account.access_token;
+      }
+
       if (user) {
         token.uid = user.id;
       }

--- a/apps/alpha/pages/api/auth/[...nextauth].js
+++ b/apps/alpha/pages/api/auth/[...nextauth].js
@@ -19,7 +19,6 @@ export default NextAuth({
       if (session?.user) {
         session.user.id = token.uid;
       }
-      session.accessToken = token.accessToken;
       return session;
     },
     jwt: async ({ user, token, account }) => {

--- a/apps/alpha/pages/api/discord/fetchMutualGuilds.ts
+++ b/apps/alpha/pages/api/discord/fetchMutualGuilds.ts
@@ -1,0 +1,54 @@
+/* eslint-disable import/no-anonymous-default-export */
+import axios from "axios";
+import _ from "lodash";
+import { NextApiRequest, NextApiResponse } from "next";
+import { getToken } from "next-auth/jwt";
+
+import { DISCORD_API_URL } from "../../../constants";
+import { FetchMutualGuildsResponse, PartialGuild } from "../../../types/type";
+
+export default async (
+  req: NextApiRequest,
+  res: NextApiResponse<FetchMutualGuildsResponse>
+) => {
+  const token = await getToken({
+    req,
+    secret: process.env.NEXT_PUBLIC_SECRET,
+  });
+
+  if (!token || !token?.accessToken) {
+    return res.status(404).end();
+  }
+
+  const guilds = await getMutualGuildsService(token.accessToken as string);
+
+  return res.status(200).send({
+    guilds: guilds,
+  });
+};
+
+function _getBotGuildsService() {
+  return axios.get<PartialGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
+    headers: {
+      Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN}`,
+    },
+  });
+}
+
+async function _getUserGuildsService(token: string) {
+  return axios.get<PartialGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+}
+
+async function getMutualGuildsService(token: string) {
+  const { data: botGuilds } = await _getBotGuildsService();
+  const { data: userGuilds } = await _getUserGuildsService(token);
+  // const adminUserGuilds = userGuilds.filter(
+  //   ({ permissions }) => (Number(permissions) & 0x8) === 0x8
+  // );
+
+  return _.intersectionWith(userGuilds, botGuilds, (a, b) => a.id === b.id);
+}

--- a/apps/alpha/pages/test/guild/index.tsx
+++ b/apps/alpha/pages/test/guild/index.tsx
@@ -1,0 +1,59 @@
+import { GetServerSidePropsContext } from "next";
+import { getSession } from "next-auth/react";
+import { useState } from "react";
+
+import { PartialGuild } from "../../../types/type";
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  const session = await getSession(ctx);
+
+  const url = ctx.req.url?.replace("/", "");
+
+  if (!session) {
+    return {
+      redirect: {
+        destination: `/login?redirect=${url}`,
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {},
+  };
+}
+
+const Guild = () => {
+  const [guilds, setGuilds] = useState<Array<PartialGuild>>([]);
+
+  return (
+    <div>
+      <button
+        onClick={async () => {
+          const result = await fetch(
+            encodeURI("/api/discord/fetchMutualGuilds")
+          );
+
+          if (result.ok) {
+            const data = await result.json();
+
+            setGuilds(data.guilds);
+          } else {
+            setGuilds([]);
+          }
+        }}
+      >
+        Test
+      </button>
+      <ul role={"list"}>
+        {guilds.length !== 0 ? (
+          guilds.map((guild) => <li key={guild.id}>{guild.name}</li>)
+        ) : (
+          <li>No Guilds</li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default Guild;

--- a/apps/alpha/types/type.ts
+++ b/apps/alpha/types/type.ts
@@ -13,6 +13,14 @@ interface PartialUser {
   bot?: boolean;
 }
 
+export interface PartialGuild {
+  id: string;
+  name: string;
+  icon: string;
+  owner: boolean;
+  permissions: string;
+}
+
 export interface PartialChannel {
   id: string;
   permissions: number;
@@ -36,6 +44,10 @@ export interface CreateThreadResponse {
 
 export interface FetchGuildMembersResponse {
   members: Array<PartialMember>;
+}
+
+export interface FetchMutualGuildsResponse {
+  guilds: Array<PartialGuild>;
 }
 
 export interface CreateThreadApiRequestBody {


### PR DESCRIPTION
### What have I done?
Add discord api in apps/alpha/pages/api/discord/fetchGuildMembers, to grab guilds that both bots and users join in.
Add a test page in apps/alpha/pages/test/guild, just go to /test/guild and click the button `Test`, you will see the api results

### Demo
https://www.loom.com/share/4ff348a1722f4b30af9fba2585798996
