### PR TITLE
Add discord-api-types to standardize discord api types

### DIFF
--- a/apps/alpha/package.json
+++ b/apps/alpha/package.json
@@ -17,6 +17,7 @@
     "@eden/package-ui": "*",
     "@vercel/og": "^0.0.20",
     "axios": "^1.1.2",
+    "discord-api-types": "^0.37.17",
     "graphql": "^16.6.0",
     "next": "^13.0.2",
     "next-auth": "^4.12.0",

--- a/apps/alpha/pages/api/discord/createMessage.ts
+++ b/apps/alpha/pages/api/discord/createMessage.ts
@@ -1,15 +1,13 @@
 /* eslint-disable camelcase */
 /* eslint-disable import/no-anonymous-default-export */
 import axios from "axios";
+import { APIMessage } from "discord-api-types/v10";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { DISCORD_API_URL } from "../../../constants";
 import {
   CreateMessageApiRequestBody,
-  //   CreateThreadApiRequestBody,
   CreateThreadResponse,
-  //   PartialChannel,
-  PartialMessage,
 } from "../../../types/type";
 
 export default async (
@@ -25,7 +23,7 @@ export default async (
       res.status(400);
     }
 
-    await axios.post<PartialMessage>(
+    await axios.post<APIMessage>(
       `${DISCORD_API_URL}/channels/${thread}/messages`,
       {
         content: message,

--- a/apps/alpha/pages/api/discord/createThread.ts
+++ b/apps/alpha/pages/api/discord/createThread.ts
@@ -1,14 +1,13 @@
 /* eslint-disable camelcase */
 /* eslint-disable import/no-anonymous-default-export */
 import axios from "axios";
+import { APIChannel, APIMessage } from "discord-api-types/v10";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { DISCORD_API_URL } from "../../../constants";
 import {
   CreateThreadApiRequestBody,
   CreateThreadResponse,
-  PartialChannel,
-  PartialMessage,
 } from "../../../types/type";
 
 export default async (
@@ -32,7 +31,7 @@ export default async (
       res.status(400);
     }
 
-    const thread = await axios.post<PartialChannel>(
+    const thread = await axios.post<APIChannel>(
       `${DISCORD_API_URL}/channels/${channelId}/threads`,
       {
         name: threadName,
@@ -47,7 +46,7 @@ export default async (
       }
     );
 
-    await axios.post<PartialMessage>(
+    await axios.post<APIMessage>(
       `${DISCORD_API_URL}/channels/${thread.data.id}/messages`,
       {
         content: message,

--- a/apps/alpha/pages/api/discord/createThread.ts
+++ b/apps/alpha/pages/api/discord/createThread.ts
@@ -24,7 +24,7 @@ export default async (
       senderName,
       channelId,
       threadName,
-      autoArchiveDuration,
+      ThreadAutoArchiveDuration,
     } = body as CreateThreadApiRequestBody;
 
     if (message) {
@@ -36,7 +36,7 @@ export default async (
       {
         name: threadName,
         // eslint-disable-next-line camelcase
-        auto_archive_duration: autoArchiveDuration,
+        auto_archive_duration: ThreadAutoArchiveDuration,
         type: 11, // public thread
       },
       {

--- a/apps/alpha/pages/api/discord/fetchGuildMembers.ts
+++ b/apps/alpha/pages/api/discord/fetchGuildMembers.ts
@@ -1,10 +1,11 @@
 /* eslint-disable import/no-anonymous-default-export */
 
 import axios from "axios";
+import { APIGuildMember } from "discord-api-types/v10";
 import { NextApiRequest, NextApiResponse } from "next";
 
 import { DISCORD_API_URL } from "../../../constants";
-import { FetchGuildMembersResponse, PartialMember } from "../../../types/type";
+import { FetchGuildMembersResponse } from "../../../types/type";
 
 export default async (
   req: NextApiRequest,
@@ -13,7 +14,7 @@ export default async (
   const { query } = req;
   const { guildId } = query;
 
-  const response = await axios.get<Array<PartialMember>>(
+  const response = await axios.get<Array<APIGuildMember>>(
     `${DISCORD_API_URL}/guilds/${guildId}/members`,
     {
       headers: {

--- a/apps/alpha/pages/api/discord/fetchGuildsOwnedBy.ts
+++ b/apps/alpha/pages/api/discord/fetchGuildsOwnedBy.ts
@@ -1,10 +1,11 @@
 /* eslint-disable import/no-anonymous-default-export */
 import axios from "axios";
+import { APIGuild } from "discord-api-types/v10";
 import { NextApiRequest, NextApiResponse } from "next";
 import { getToken } from "next-auth/jwt";
 
 import { DISCORD_API_URL } from "../../../constants";
-import { FetchMutualGuildsResponse, PartialGuild } from "../../../types/type";
+import { FetchMutualGuildsResponse } from "../../../types/type";
 
 export default async (
   req: NextApiRequest,
@@ -27,7 +28,7 @@ export default async (
 };
 
 async function _getUserGuildsService(token: string) {
-  return axios.get<PartialGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
+  return axios.get<APIGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
     headers: {
       Authorization: `Bearer ${token}`,
     },

--- a/apps/alpha/pages/api/discord/fetchMemberGuilds.ts
+++ b/apps/alpha/pages/api/discord/fetchMemberGuilds.ts
@@ -1,10 +1,11 @@
 /* eslint-disable import/no-anonymous-default-export */
 import axios from "axios";
+import { APIGuild } from "discord-api-types/v10";
 import { NextApiRequest, NextApiResponse } from "next";
 import { getToken } from "next-auth/jwt";
 
 import { DISCORD_API_URL } from "../../../constants";
-import { FetchMutualGuildsResponse, PartialGuild } from "../../../types/type";
+import { FetchMutualGuildsResponse } from "../../../types/type";
 
 export default async (
   req: NextApiRequest,
@@ -27,7 +28,7 @@ export default async (
 };
 
 async function _getUserGuildsService(token: string) {
-  return axios.get<PartialGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
+  return axios.get<APIGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
     headers: {
       Authorization: `Bearer ${token}`,
     },

--- a/apps/alpha/pages/api/discord/fetchMutualGuilds.ts
+++ b/apps/alpha/pages/api/discord/fetchMutualGuilds.ts
@@ -1,11 +1,12 @@
 /* eslint-disable import/no-anonymous-default-export */
 import axios from "axios";
+import { APIGuild } from "discord-api-types/v10";
 import _ from "lodash";
 import { NextApiRequest, NextApiResponse } from "next";
 import { getToken } from "next-auth/jwt";
 
 import { DISCORD_API_URL } from "../../../constants";
-import { FetchMutualGuildsResponse, PartialGuild } from "../../../types/type";
+import { FetchMutualGuildsResponse } from "../../../types/type";
 
 export default async (
   req: NextApiRequest,
@@ -28,7 +29,7 @@ export default async (
 };
 
 function _getBotGuildsService() {
-  return axios.get<PartialGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
+  return axios.get<APIGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
     headers: {
       Authorization: `Bot ${process.env.DISCORD_BOT_TOKEN}`,
     },
@@ -36,7 +37,7 @@ function _getBotGuildsService() {
 }
 
 async function _getUserGuildsService(token: string) {
-  return axios.get<PartialGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
+  return axios.get<APIGuild[]>(`${DISCORD_API_URL}/users/@me/guilds`, {
     headers: {
       Authorization: `Bearer ${token}`,
     },

--- a/apps/alpha/pages/chat/index.tsx
+++ b/apps/alpha/pages/chat/index.tsx
@@ -153,7 +153,7 @@ const ChatPage: NextPageWithLayout = (session) => {
                 senderName: `${currentUser?.discordName} -- Just invite you to a conversation`,
                 channelId: "1033337923006902353",
                 threadName: `Project Talents Discussion with ${member?.discordName}`,
-                autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
+                ThreadAutoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
               });
 
               const result = await addNewChat({

--- a/apps/alpha/pages/chat/index.tsx
+++ b/apps/alpha/pages/chat/index.tsx
@@ -18,6 +18,7 @@ import {
   SEO,
   TextField,
 } from "@eden/package-ui";
+import { ThreadAutoArchiveDuration } from "discord-api-types/v10";
 import { useContext, useState } from "react";
 
 import type { NextPageWithLayout } from "../_app";
@@ -152,7 +153,7 @@ const ChatPage: NextPageWithLayout = (session) => {
                 senderName: `${currentUser?.discordName} -- Just invite you to a conversation`,
                 channelId: "1001547443135058010",
                 threadName: `Project Talents Discussion with ${member?.discordName}`,
-                autoArchiveDuration: AutoArchiveDuration.OneDay,
+                autoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
               });
 
               const result = await addNewChat({
@@ -188,7 +189,6 @@ import { IncomingMessage, ServerResponse } from "http";
 import { getSession } from "next-auth/react";
 
 import {
-  AutoArchiveDuration,
   CreateThreadApiRequestBody,
   CreateThreadResponse,
 } from "../../types/type";

--- a/apps/alpha/pages/test/guild/index.tsx
+++ b/apps/alpha/pages/test/guild/index.tsx
@@ -1,8 +1,7 @@
+import { APIGuild } from "discord-api-types/v10";
 import { GetServerSidePropsContext } from "next";
 import { getSession } from "next-auth/react";
 import { useState } from "react";
-
-import { PartialGuild } from "../../../types/type";
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const session = await getSession(ctx);
@@ -24,7 +23,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 }
 
 const Guild = () => {
-  const [guilds, setGuilds] = useState<Array<PartialGuild>>([]);
+  const [guilds, setGuilds] = useState<Array<APIGuild>>([]);
 
   return (
     <div>

--- a/apps/alpha/types/type.ts
+++ b/apps/alpha/types/type.ts
@@ -1,53 +1,20 @@
 /* eslint-disable no-unused-vars */
-export interface PartialMember {
-  user?: PartialUser;
-  nick?: string;
-  avatar?: string;
-}
-
-interface PartialUser {
-  id: string;
-  username: string;
-  discriminator: string;
-  avatar: string;
-  bot?: boolean;
-}
-
-export interface PartialGuild {
-  id: string;
-  name: string;
-  icon: string;
-  owner: boolean;
-  permissions: string;
-}
-
-export interface PartialChannel {
-  id: string;
-  permissions: number;
-}
-
-export interface PartialMessage {
-  id: string;
-  channel_id: string;
-}
-
-export enum AutoArchiveDuration {
-  OneHour = 60,
-  OneDay = 1440,
-  ThreeDay = 4320,
-  SevenDay = 10080,
-}
+import {
+  APIGuild,
+  APIGuildMember,
+  ThreadAutoArchiveDuration,
+} from "discord-api-types/v10";
 
 export interface CreateThreadResponse {
   threadId: string;
 }
 
 export interface FetchGuildMembersResponse {
-  members: Array<PartialMember>;
+  members: Array<APIGuildMember>;
 }
 
 export interface FetchMutualGuildsResponse {
-  guilds: Array<PartialGuild>;
+  guilds: Array<APIGuild>;
 }
 
 export interface CreateThreadApiRequestBody {
@@ -57,7 +24,7 @@ export interface CreateThreadApiRequestBody {
   senderAvatarURL: string;
   channelId: string;
   threadName: string;
-  autoArchiveDuration: AutoArchiveDuration;
+  autoArchiveDuration: ThreadAutoArchiveDuration;
 }
 
 export interface CreateMessageApiRequestBody {
@@ -68,5 +35,5 @@ export interface CreateMessageApiRequestBody {
   senderAvatarURL?: string;
   channelId?: string;
   threadName?: string;
-  autoArchiveDuration?: AutoArchiveDuration;
+  autoArchiveDuration?: ThreadAutoArchiveDuration;
 }

--- a/apps/alpha/types/type.ts
+++ b/apps/alpha/types/type.ts
@@ -24,7 +24,7 @@ export interface CreateThreadApiRequestBody {
   senderAvatarURL: string;
   channelId: string;
   threadName: string;
-  autoArchiveDuration: ThreadAutoArchiveDuration;
+  ThreadAutoArchiveDuration: ThreadAutoArchiveDuration;
 }
 
 export interface CreateMessageApiRequestBody {
@@ -35,5 +35,5 @@ export interface CreateMessageApiRequestBody {
   senderAvatarURL?: string;
   channelId?: string;
   threadName?: string;
-  autoArchiveDuration?: ThreadAutoArchiveDuration;
+  ThreadAutoArchiveDuration?: ThreadAutoArchiveDuration;
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,7 @@
     "@heroicons/react": "^1.0.6",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
+    "@types/uuid": "^8.3.4",
     "chart.js": "^3.9.1",
     "clsx": "^1.2.1",
     "emoji-picker-react": "^3.6.1",
@@ -29,14 +30,14 @@
     "react-confetti": "^6.1.0",
     "react-multi-date-picker": "^3.3.0",
     "react-tooltip": "^4.2.21",
-    "typescript": "^4.8.4",
-    "@types/uuid": "^8.3.4"
+    "typescript": "^4.8.4"
   },
   "dependencies": {
-    "uuid": "^9.0.0",
     "chart.js": "^3.9.1",
     "date-fns": "^2.29.3",
+    "discord-api-types": "^0.37.17",
     "react-chartjs-2": "^4.3.1",
-    "react-compound-slider": "^3.4.0"
+    "react-compound-slider": "^3.4.0",
+    "uuid": "^9.0.0"
   }
 }

--- a/packages/ui/src/components/SendMessageToChampion/SendMessageToChampion.tsx
+++ b/packages/ui/src/components/SendMessageToChampion/SendMessageToChampion.tsx
@@ -15,11 +15,11 @@ import {
   TextArea,
   TextHeading3,
 } from "@eden/package-ui";
+import { ThreadAutoArchiveDuration } from "discord-api-types/v10";
 import { useContext, useState } from "react";
 import { toast } from "react-toastify";
 
 import {
-  AutoArchiveDuration,
   CreateMessageApiRequestBody,
   CreateThreadApiRequestBody,
   CreateThreadResponse,
@@ -127,7 +127,7 @@ export const SendMessageToChampion = ({
       senderName: `${currentUser?.discordName} - is interested in ${project?.title}`,
       channelId: "1033337923006902353",
       threadName: `${project?.title}, has a new message from ${currentUser?.discordName}`,
-      autoArchiveDuration: AutoArchiveDuration.OneDay,
+      ThreadAutoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
     });
 
     try {

--- a/packages/ui/src/components/SendMessageToUser/SendMessageToUser.tsx
+++ b/packages/ui/src/components/SendMessageToUser/SendMessageToUser.tsx
@@ -15,11 +15,11 @@ import {
   TextArea,
   TextHeading3,
 } from "@eden/package-ui";
+import { ThreadAutoArchiveDuration } from "discord-api-types/v10";
 import { useContext, useState } from "react";
 import { toast } from "react-toastify";
 
 import {
-  AutoArchiveDuration,
   CreateMessageApiRequestBody,
   CreateThreadApiRequestBody,
   CreateThreadResponse,
@@ -124,15 +124,15 @@ export const SendMessageToUser = ({
       embedMessage: embededMessage,
       senderAvatarURL: currentUser?.discordAvatar!,
       senderName: `${currentUser?.discordName} - Invited you to join ${project?.title}`,
-      channelId: "1033337923006902353",
+      channelId: "1001547443135058010",
       threadName: `Project Talents Discussion with ${member?.discordName}`,
-      autoArchiveDuration: AutoArchiveDuration.OneDay,
+      ThreadAutoArchiveDuration: ThreadAutoArchiveDuration.OneDay,
     });
 
     try {
       await createMessage({
         message: followUpMessage,
-        channelId: "1033337923006902353",
+        channelId: "1001547443135058010",
         thread: threadId,
       });
     } catch (error) {
@@ -147,7 +147,7 @@ export const SendMessageToUser = ({
             projectID: "62f685952dc2d40004d395c7",
             receiverID: member?._id!,
             senderID: currentUser?._id!,
-            serverID: "996558082098339953",
+            serverID: "988301790795685930",
             threadID: threadId,
           },
         },

--- a/packages/ui/types/type.ts
+++ b/packages/ui/types/type.ts
@@ -1,41 +1,19 @@
 /* eslint-disable no-unused-vars */
-export interface PartialMember {
-  user?: PartialUser;
-  nick?: string;
-  avatar?: string;
-}
-
-interface PartialUser {
-  id: string;
-  username: string;
-  discriminator: string;
-  avatar: string;
-  bot?: boolean;
-}
-
-export interface PartialChannel {
-  id: string;
-  permissions: number;
-}
-
-export interface PartialMessage {
-  id: string;
-  channel_id: string;
-}
-
-export enum AutoArchiveDuration {
-  OneHour = 60,
-  OneDay = 1440,
-  ThreeDay = 4320,
-  SevenDay = 10080,
-}
-
+import {
+  APIGuild,
+  APIGuildMember,
+  ThreadAutoArchiveDuration,
+} from "discord-api-types/v10";
 export interface CreateThreadResponse {
   threadId: string;
 }
 
 export interface FetchGuildMembersResponse {
-  members: Array<PartialMember>;
+  members: Array<APIGuildMember>;
+}
+
+export interface FetchMutualGuildsResponse {
+  guilds: Array<APIGuild>;
 }
 
 export interface CreateThreadApiRequestBody {
@@ -45,7 +23,7 @@ export interface CreateThreadApiRequestBody {
   senderAvatarURL: string;
   channelId: string;
   threadName: string;
-  autoArchiveDuration: AutoArchiveDuration;
+  ThreadAutoArchiveDuration: ThreadAutoArchiveDuration;
 }
 
 export interface CreateMessageApiRequestBody {
@@ -56,5 +34,5 @@ export interface CreateMessageApiRequestBody {
   senderAvatarURL?: string;
   channelId?: string;
   threadName?: string;
-  autoArchiveDuration?: AutoArchiveDuration;
+  ThreadAutoArchiveDuration?: ThreadAutoArchiveDuration;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6434,6 +6434,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+discord-api-types@^0.37.17:
+  version "0.37.17"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.37.17.tgz#314e4225fdff31b08b83ba5104d46564bc02303c"
+  integrity sha512-5ZIw1VtkmToBy8ziketjHkZnW1FoLevyXdK/TslNFLozijug2RnB3MyBNtSGzML1c72koU3neeGkvFZ8OiU0tQ==
+
 dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"


### PR DESCRIPTION
## What have I done?
Add one more dependency in alpha version --- discord-api-types, including Discord API types and utils. Replace all self-defined discord API types, like PartialGuild, PartialUser....

## How to use this dependency
```ts
  // Covering most of API Types, not sure why compiler cannot auto import
  // Before using unfamiliar properties, please read its doc: https://discord.com/developers/docs/resources/application
  import { } from "discord-api-types/v10"; 
```
