### PR TITLE
add tests for `ProjectsMatchesModal`

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
     "@jaames/iro": "^5.5.2",
     "@swc/core": "^1.3.21",
     "@swc/jest": "^0.2.23",
+    "@testing-library/user-event": "^14.4.3",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
     "@types/uuid": "^8.3.4",

--- a/packages/ui/src/modals/ProjectsMatchesModal/ProjectsMatchesModal.test.tsx
+++ b/packages/ui/src/modals/ProjectsMatchesModal/ProjectsMatchesModal.test.tsx
@@ -1,10 +1,76 @@
-import { render } from "../../../utils/jest-apollo";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
 import { ProjectsMatchesModal } from ".";
 
-describe("ProjectsMatchesModal", () => {
-  it("renders without throwing", () => {
-    const { container } = render(<ProjectsMatchesModal />);
+window.IntersectionObserver = jest.fn().mockReturnValue({
+  observe: () => null,
+  unobserve: () => null,
+  disconnect: () => null,
+});
 
-    expect(container).toBeInTheDocument();
-  });
+test("openModal controls whether modal is rendered", () => {
+  const { rerender } = render(<ProjectsMatchesModal openModal={false} />);
+
+  expect(screen.queryByRole("dialog")).toBeNull();
+
+  rerender(<ProjectsMatchesModal openModal />);
+
+  expect(screen.getByRole("dialog")).toBeInTheDocument();
+});
+
+test("dynamic text content is placed in the correct containers", () => {
+  render(
+    <ProjectsMatchesModal
+      openModal
+      header1="Header1"
+      header2="Header2"
+      matchType="matchType"
+      topLeftText="topLeftText"
+      bottomLeftText="bottomLeftText"
+      numMatchesBefore={10}
+      topRightText="topRightText"
+      bottomRightText="bottomRightText"
+      numMatchesAfter={20}
+    />
+  );
+
+  expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+    "Header1"
+  );
+  expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+    "Header2"
+  );
+
+  const left = within(screen.getAllByRole("list")[1]);
+
+  {
+    const listitems = left.getAllByRole("listitem");
+
+    expect(listitems[0]).toHaveTextContent("topLeftText");
+    expect(listitems[1]).toHaveTextContent("10matchType");
+    expect(listitems[2]).toHaveTextContent("bottomLeftText");
+  }
+
+  const right = within(screen.getAllByRole("list")[2]);
+
+  {
+    const listitems = right.getAllByRole("listitem");
+
+    expect(listitems[0]).toHaveTextContent("topRightText");
+    expect(listitems[1]).toHaveTextContent("20matchType");
+    expect(listitems[2]).toHaveTextContent("bottomRightText");
+  }
+});
+
+test("next button calls onSubmit callback", async () => {
+  const user = userEvent.setup();
+
+  const onSubmit = jest.fn();
+
+  render(<ProjectsMatchesModal openModal onSubmit={onSubmit} />);
+
+  await user.click(screen.getByRole("button", { name: "Next" }));
+
+  expect(onSubmit).toHaveBeenCalled();
 });

--- a/packages/ui/src/modals/ProjectsMatchesModal/ProjectsMatchesModal.tsx
+++ b/packages/ui/src/modals/ProjectsMatchesModal/ProjectsMatchesModal.tsx
@@ -40,43 +40,39 @@ export const ProjectsMatchesModal = ({
   <>
     <Modal open={openModal} closeOnEsc={false}>
       <div className="space-y-4 pl-4">
-        <div>
-          <p className="text-2xl ">{header1}</p>
-        </div>
-        <div>
-          <p className="tracking-wider">{header2}</p>
-        </div>
+        <h1 className="text-2xl">{header1}</h1>
+        <h2 className="tracking-wider">{header2}</h2>
       </div>
-      <div className="my-4 flex justify-center space-x-6 px-6">
-        <div className="flex h-60 w-60 justify-center rounded-md border-2">
-          <div className="flex flex-col items-center justify-center space-y-2">
-            <div>{topLeftText}</div>
-            <div className="mx-4">
+      <ol className="my-4 flex justify-center space-x-6 px-6">
+        <li className="flex h-60 w-60 justify-center rounded-md border-2">
+          <ol className="flex flex-col items-center justify-center space-y-2">
+            <li>{topLeftText}</li>
+            <li className="mx-4">
               <BatteryStepper
                 batteryPercentage={batteryPercentageBefore}
                 numMatches={numMatchesBefore}
                 size={"sm"}
                 text={matchType}
               />
-            </div>
-            <div>{bottomLeftText}</div>
-          </div>
-        </div>
-        <div className="flex h-60 w-60 justify-center rounded-md border-2">
-          <div className="flex flex-col items-center justify-center space-y-2">
-            <div> {topRightText}</div>
-            <div className="mx-4">
+            </li>
+            <li>{bottomLeftText}</li>
+          </ol>
+        </li>
+        <li className="flex h-60 w-60 justify-center rounded-md border-2">
+          <ol className="flex flex-col items-center justify-center space-y-2">
+            <li>{topRightText}</li>
+            <li className="mx-4">
               <BatteryStepper
                 batteryPercentage={batteryPercentageAfter}
                 numMatches={numMatchesAfter}
                 size={"sm"}
                 text={matchType}
               />
-            </div>
-            <div>{bottomRightText}</div>
-          </div>
-        </div>
-      </div>
+            </li>
+            <li>{bottomRightText}</li>
+          </ol>
+        </li>
+      </ol>
       <div className="flex justify-end">
         <Button
           radius="rounded"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3500,6 +3500,11 @@
     "@testing-library/dom" "^8.5.0"
     "@types/react-dom" "^18.0.0"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"


### PR DESCRIPTION
This PR adds test coverage for `ProjectsMatchesModal`.

To implement these tests, I had to make some minor alterations to the `html` structure of the component. I'll add comments explaining those changes.

Things we tested:

- the `openModal` prop controls whether the component is rendered
- custom text content props are present in the output and have a generally correct structure
- pressing the "Next" button calls the `onSubmit` callback prop