### PR TITLE
fixed profile fill precentages - kind of

### DIFF
--- a/apps/nodes/pages/onboard/party/[partyId].tsx
+++ b/apps/nodes/pages/onboard/party/[partyId].tsx
@@ -279,6 +279,7 @@ const OnboardPartyPage: NextPageWithLayout = () => {
             <Card shadow className={`bg-white p-4`}>
               <div className={``}>
                 <TextHeading3>Best people for you to meet:</TextHeading3>
+
                 <div className={`text-sm text-zinc-500`}>
                   Powered by Eden AI
                 </div>
@@ -317,6 +318,12 @@ const OnboardPartyPage: NextPageWithLayout = () => {
                         );
                       }
                     )}
+                  {currentUser?.nodes?.length === 0 && (
+                    <TextHeading3 className={`text-blue-700`}>
+                      Add Skills and Preferred Projects on Your Profile to find
+                      best matches
+                    </TextHeading3>
+                  )}
                   <button onClick={() => refetchMatchMembers()}>
                     <BiRefresh className="text-3xl text-zinc-400" />
                   </button>

--- a/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.tsx
+++ b/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.tsx
@@ -187,7 +187,7 @@ export const EditProfileOnboardPartyNodesCard = ({
         <TextLabel>PREFERRED PROJECTS</TextLabel>
         {/* {learningSkills && <NumberCircle value={learningSkills?.length} />} */}
         <button onClick={() => setOpenModalTypeProject(true)}>
-          <BiCommentAdd className="text-2xl text-zinc-400" />
+          <BiCommentAdd className="text-soilPurple hover:text-accentColor text-2xl" />
         </button>
       </div>
       <div>
@@ -214,7 +214,7 @@ export const EditProfileOnboardPartyNodesCard = ({
         <TextLabel>SKILLS</TextLabel>
         {/* {skilledSkills && <NumberCircle value={skilledSkills?.length} />} */}
         <button onClick={() => setOpenModalExpertise(true)}>
-          <BiCommentAdd className="text-2xl text-zinc-400" />
+          <BiCommentAdd className="text-soilPurple hover:text-accentColor text-2xl" />
         </button>{" "}
       </div>
       <div>

--- a/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.tsx
+++ b/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.tsx
@@ -18,16 +18,16 @@ import {
 import { useContext, useState } from "react";
 import { BiCommentAdd } from "react-icons/bi";
 
-import { getUserProgressNodes } from "../../../utils/user-progress-nodes";
+import { getFillProfilePercentage } from "../../../utils/fill-profile-percentage";
 
-export const ADD_NODES = gql`
+const ADD_NODES = gql`
   mutation ($fields: addNodesToMemberInRoomInput) {
     addNodesToMemberInRoom(fields: $fields) {
       _id
     }
   }
 `;
-// export const ADD_NODES = gql`
+// const ADD_NODES = gql`
 //   mutation ($fields: addNodesToMemberInput!) {
 //     addNodesToMember(fields: $fields) {
 //       _id
@@ -35,7 +35,7 @@ export const ADD_NODES = gql`
 //   }
 // `;
 
-export const DELETE_NODES = gql`
+const DELETE_NODES = gql`
   mutation ($fields: deleteNodesFromMemberInRoomInput) {
     deleteNodesFromMemberInRoom(fields: $fields) {
       _id
@@ -43,7 +43,7 @@ export const DELETE_NODES = gql`
   }
 `;
 
-// export const DELETE_NODES = gql`
+// const DELETE_NODES = gql`
 //   mutation ($fields: deleteNodesFromMemberInput!) {
 //     deleteNodesFromMember(fields: $fields) {
 //       _id
@@ -74,7 +74,7 @@ export const EditProfileOnboardPartyNodesCard = ({
     context: { serviceName: "soilservice" },
   });
 
-  const progress = getUserProgressNodes(currentUser || {});
+  const progress = getFillProfilePercentage(currentUser || {});
 
   const _handleUpdateUser = (e: any) => {
     handleUpdateUser(e.target.value, e.target.name);

--- a/packages/ui/src/cards/GrantsCard/GrantsCard.tsx
+++ b/packages/ui/src/cards/GrantsCard/GrantsCard.tsx
@@ -90,7 +90,7 @@ export const GrantsCard = ({ grant }: IGrantsCardProps) => {
       <div className={`font-Inter text-lg font-medium text-zinc-400`}>
         Distributed to date:{" "}
         <span className={`text-accentColor text-xl uppercase`}>
-          {grant?.distributed}/{grant?.maxDistributed}
+          {grant?.distributed || 0}/{grant?.maxDistributed}
         </span>
       </div>
 

--- a/packages/ui/src/cards/user/UserCardOnboardPartyNodes/UserCardOnboardPartyNodes.tsx
+++ b/packages/ui/src/cards/user/UserCardOnboardPartyNodes/UserCardOnboardPartyNodes.tsx
@@ -10,7 +10,7 @@ import {
   TextLabel,
 } from "@eden/package-ui";
 
-import { getUserProgressNodes } from "../../../../utils/user-progress-nodes";
+import { getFillProfilePercentage } from "../../../../utils/fill-profile-percentage";
 
 export interface IUserCardOnboardPartyNodesProps {
   member: Members;
@@ -19,7 +19,7 @@ export interface IUserCardOnboardPartyNodesProps {
 export const UserCardOnboardPartyNodes = ({
   member,
 }: IUserCardOnboardPartyNodesProps) => {
-  const progress = getUserProgressNodes(member);
+  const progress = getFillProfilePercentage(member);
 
   return (
     <Card border className="border-soilGray col-span-1 bg-white p-3">
@@ -34,16 +34,12 @@ export const UserCardOnboardPartyNodes = ({
           <div>
             <TextHeading3 className="-mt-3">{member.discordName}</TextHeading3>
             {member.memberRole && (
-              <p className="text-xs font-medium leading-none">
+              <p className="text-xs font-medium leading-none text-zinc-500">
                 <span className="mr-1">💼</span>
                 {member.memberRole.title?.toUpperCase()}
               </p>
             )}
             {/* <SocialMediaComp links={member.links} title="" size="18px" /> */}
-          </div>
-
-          <div className={`text-md ml-2 font-medium text-zinc-400`}>
-            {member?.memberRole?.title}
           </div>
         </div>
       </div>

--- a/packages/ui/src/containers/GrantsModalContainer/GrantsModalContainer.tsx
+++ b/packages/ui/src/containers/GrantsModalContainer/GrantsModalContainer.tsx
@@ -1,4 +1,4 @@
-import { GrantsContext, GrantsModal } from "@eden/package-context";
+import { GrantsContext, GrantsModal, UserContext } from "@eden/package-context";
 import {
   DiscoverTalentDropdownModal,
   ProjectsMatchesModal,
@@ -6,6 +6,8 @@ import {
   WarningModal,
 } from "@eden/package-ui";
 import { useContext, useEffect, useState } from "react";
+
+import { getFillProfilePercentage } from "../../../utils/fill-profile-percentage";
 
 const rangeNumbers: number[] = [];
 
@@ -21,7 +23,7 @@ export interface IGrantsModalContainerProps {
 export const GrantsModalContainer = ({
   setArrayOfNodes,
 }: IGrantsModalContainerProps) => {
-  // const { project, openModal, setOpenModal } = useContext(GrantsContext);
+  const { currentUser } = useContext(UserContext);
   const { openModal, setOpenModal } = useContext(GrantsContext);
 
   const [nextStep, setNextStep] = useState<any>(null);
@@ -44,7 +46,7 @@ export const GrantsModalContainer = ({
           openModal={openModal === GrantsModal.SKIP_ALERT}
           onSkipStep={() => setOpenModal(nextStep)}
           onSkipFlow={() => setOpenModal(null)}
-          percentage={30}
+          percentage={getFillProfilePercentage(currentUser || {})}
         />
       )}
 
@@ -73,7 +75,7 @@ export const GrantsModalContainer = ({
           }}
           // eslint-disable-next-line no-unused-vars
           onSubmit={(val: string[]) => {
-            console.log("val", val);
+            // console.log("val", val);
             if (val) {
               if (setNodeIdArray) setNodeIdArray([...nodeIdArray, ...val]);
             }
@@ -83,7 +85,7 @@ export const GrantsModalContainer = ({
           subTitle={`Choose any role you want!`}
           nodeType={`expertise`}
           matchType={matchType}
-          batteryPercentage={20}
+          batteryPercentage={getFillProfilePercentage(currentUser || {})}
         />
       )}
 
@@ -96,24 +98,28 @@ export const GrantsModalContainer = ({
           }}
           // eslint-disable-next-line no-unused-vars
           onSubmit={(val: string[] | null) => {
-            console.log("val", val);
+            // console.log("val", val);
             if (val) {
               if (setNodeIdArray) setNodeIdArray([...nodeIdArray, ...val]);
             }
-            setOpenModal(GrantsModal.WARNING);
+            if (getFillProfilePercentage(currentUser || {}) < 60) {
+              setOpenModal(GrantsModal.WARNING);
+            } else {
+              setOpenModal(null);
+            }
           }}
           title={`Let's get you sorted! What type of projects are you looking for?`}
           subTitle={`You can choose any area of interest!`}
           nodeType={`typeProject`}
           matchType={matchType}
-          batteryPercentage={60}
+          batteryPercentage={getFillProfilePercentage(currentUser || {})}
         />
       )}
 
       {openModal === GrantsModal.WARNING && (
         <WarningModal
           openModal
-          profilePercentage={20}
+          profilePercentage={getFillProfilePercentage(currentUser || {})}
           canSeeProjects={true}
           canProjectsSee={false}
           onSkip={function (): void {

--- a/packages/ui/src/containers/nodes/NodesOnboardPartyContainer/NodesOnboardPartyContainer.tsx
+++ b/packages/ui/src/containers/nodes/NodesOnboardPartyContainer/NodesOnboardPartyContainer.tsx
@@ -6,7 +6,7 @@ import {
   UserCardOnboardPartyNodes,
 } from "@eden/package-ui";
 
-import { getUserProgressNodes } from "../../../../utils/user-progress-nodes";
+import { getFillProfilePercentage } from "../../../../utils/fill-profile-percentage";
 
 export interface INodesOnboardPartyContainerProps {
   members: Members[];
@@ -26,7 +26,8 @@ export const NodesOnboardPartyContainer = ({
           {[...members]
             .sort(
               (a: Members, b: Members) =>
-                (getUserProgressNodes(b) || 0) - (getUserProgressNodes(a) || 0)
+                (getFillProfilePercentage(b) || 0) -
+                (getFillProfilePercentage(a) || 0)
             )
             .map((member: Members, index: number) => (
               <UserCardOnboardPartyNodes key={index} member={member} />

--- a/packages/ui/src/info/GrantsInfo/GrantsInfo.tsx
+++ b/packages/ui/src/info/GrantsInfo/GrantsInfo.tsx
@@ -15,6 +15,7 @@ export interface IGrantsInfoProps {
 
 export const GrantsInfo = ({ grant }: IGrantsInfoProps) => {
   if (!grant) return null;
+
   return (
     <div>
       <div className={`flex`}>
@@ -145,7 +146,7 @@ export const GrantsInfo = ({ grant }: IGrantsInfoProps) => {
             <div
               className={`text-accentColor my-1 rounded-xl bg-blue-50 p-4 text-xl uppercase shadow-md`}
             >
-              {grant?.distributed}/{grant?.maxDistributed}
+              {grant?.distributed || 0}/{grant?.maxDistributed}
             </div>
           </div>
         </div>

--- a/packages/ui/src/modals/GrantsModal/GrantsModal.tsx
+++ b/packages/ui/src/modals/GrantsModal/GrantsModal.tsx
@@ -51,7 +51,7 @@ export const GrantsModal = ({ grant, open, onClose }: IGrantsModalProps) => {
       toast.error("Your profile must be filled 50% minimum");
       return;
     }
-    setIsApplying(true);
+    // setIsApplying(true);
     // applyGrant({
     //   variables: {
     //     fields: {
@@ -61,9 +61,8 @@ export const GrantsModal = ({ grant, open, onClose }: IGrantsModalProps) => {
     //   },
     // });
 
-    window.location.href = getDynamicURL(
-      "https://airtable.com/shrs5Y5wNEISaB7Uc",
-      [
+    window.open(
+      getDynamicURL("https://airtable.com/shrs5Y5wNEISaB7Uc", [
         {
           name: "prefill_Eden+Profile",
           value:
@@ -76,7 +75,8 @@ export const GrantsModal = ({ grant, open, onClose }: IGrantsModalProps) => {
           value:
             `${currentUser?.discordName}#${currentUser?.discriminator}` || "",
         },
-      ]
+      ]),
+      "_blank"
     );
   };
 

--- a/packages/ui/src/modals/WarningModal/WarningModal.tsx
+++ b/packages/ui/src/modals/WarningModal/WarningModal.tsx
@@ -36,7 +36,7 @@ export const WarningModal = ({
             <IoIosWarning size={70} color={"FF7E5C"} />
           </div>
           <div className="mt-auto flex w-full justify-center text-slate-400">
-            <p>{`Your profile has to be 60% + complete`}</p>
+            <p>{`Your profile has to be 50% + complete`}</p>
           </div>
         </div>
         <div className="justify-center pl-20 pr-12 pb-10">

--- a/packages/ui/utils/fill-profile-percentage.tsx
+++ b/packages/ui/utils/fill-profile-percentage.tsx
@@ -3,6 +3,7 @@ import { LinkType } from "@eden/package-graphql/generated";
 export const getFillProfilePercentage = (user: any) => {
   let progress = 0;
 
+  if (!!user.nodes?.length) progress += 5 * Math.min(user.nodes?.length, 12);
   if (!!user?.memberRole) progress += 10;
   if (!!user?.links)
     progress += user?.links.reduce((acc: number, link: LinkType) => {
@@ -13,6 +14,8 @@ export const getFillProfilePercentage = (user: any) => {
     progress += user?.background.reduce((acc: number, experience: any) => {
       return !!experience.title && acc < 30 ? acc + 10 : acc;
     }, 0);
+
+  if (progress > 100) progress = 100;
 
   return Math.ceil(progress);
 };


### PR DESCRIPTION
updateMember and addNode/deleteNode are 2 different sets of mutations, so this will create an extra query for adding to the user's onboard percentages on the db when using addNode/deleteNode mutation.  

Best approach might be to just measure the user's onboarding percentages locally with the util fill-profile-percentage.tsx function?

This function is necessary on the page level also currently, so it might be good to establish a library of util functions that are global, instead of keeping in the ui package