### PR TITLE
using mock data in tests

### DIFF
--- a/packages/ui/src/cards/EditProfileOnboardPartyCard/EditProfileOnboardPartyCard.test.tsx
+++ b/packages/ui/src/cards/EditProfileOnboardPartyCard/EditProfileOnboardPartyCard.test.tsx
@@ -1,5 +1,6 @@
 // import { render } from "../../../utils/jest-apollo";
 import { MockedProvider } from "@apollo/client/testing";
+import { getMember } from "@eden/package-mock";
 import { render } from "@testing-library/react";
 
 import { EditProfileOnboardPartyCard } from ".";
@@ -9,12 +10,7 @@ describe("EditProfileOnboardPartyCard", () => {
     const { container } = render(
       <MockedProvider>
         <EditProfileOnboardPartyCard
-          currentUser={{
-            _id: "123412342134",
-            discordAvatar: undefined,
-            discordName: undefined,
-            skills: undefined,
-          }}
+          currentUser={getMember()}
           handleUpdateUser={function (): void {
             throw new Error("Function not implemented.");
           }}

--- a/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.test.tsx
+++ b/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.test.tsx
@@ -8,11 +8,7 @@ describe("EditProfileOnboardPartyNodesCard", () => {
   it("renders without throwing", () => {
     const { container } = render(
       <MockedProvider>
-        <EditProfileOnboardPartyNodesCard
-          handleUpdateUser={function (): void {
-            throw new Error("Function not implemented.");
-          }}
-        />
+        <EditProfileOnboardPartyNodesCard serverID={`12345`} RoomID={`12345`} />
       </MockedProvider>
     );
 

--- a/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.tsx
+++ b/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.tsx
@@ -67,8 +67,6 @@ const DELETE_NODES = gql`
 export interface IEditProfileOnboardPartyNodesCardProps {
   serverID: string;
   RoomID: string;
-  // eslint-disable-next-line no-unused-vars
-  // handleUpdateUser: (val: any, name: string) => void;
 }
 
 // eslint-disable-next-line no-unused-vars

--- a/packages/ui/src/cards/user/UserCardOnboardParty/UserCardOnboardParty.test.tsx
+++ b/packages/ui/src/cards/user/UserCardOnboardParty/UserCardOnboardParty.test.tsx
@@ -1,19 +1,11 @@
+import { getMember } from "@eden/package-mock";
+
 import { render } from "../../../../utils/jest-apollo";
 import { UserCardOnboardParty } from ".";
 
 describe("UserCardOnboardParty", () => {
   it("renders without throwing", () => {
-    const { container } = render(
-      <UserCardOnboardParty
-        member={{
-          _id: undefined,
-          bio: undefined,
-          discordAvatar: undefined,
-          discordName: undefined,
-          skills: [],
-        }}
-      />
-    );
+    const { container } = render(<UserCardOnboardParty member={getMember()} />);
 
     expect(container).toBeInTheDocument();
   });

--- a/packages/ui/src/cards/user/UserCardOnboardPartyNodes/UserCardOnboardPartyNodes.test.tsx
+++ b/packages/ui/src/cards/user/UserCardOnboardPartyNodes/UserCardOnboardPartyNodes.test.tsx
@@ -1,18 +1,12 @@
+import { getMember } from "@eden/package-mock";
+
 import { render } from "../../../../utils/jest-apollo";
 import { UserCardOnboardPartyNodes } from ".";
 
 describe("UserCardOnboardPartyNodes", () => {
   it("renders without throwing", () => {
     const { container } = render(
-      <UserCardOnboardPartyNodes
-        member={{
-          _id: undefined,
-          bio: undefined,
-          discordAvatar: undefined,
-          discordName: undefined,
-          skills: [],
-        }}
-      />
+      <UserCardOnboardPartyNodes member={getMember()} />
     );
 
     expect(container).toBeInTheDocument();


### PR DESCRIPTION
Here I'm using `import { getMember } from "@eden/package-mock";` inside test files

This is a faker mock for the `Members` type

It was first created to use inside storybook for building components.

Seems to work fine for tests also.

I have been pushing for creation of more mock data that replicates object types and API queries from the backend.

@with-heart do you have any thoughts on this and if this is not usable when passing mock data into the props for test files?