### PR TITLE
add tests for ProjectStatusCard

### DIFF
--- a/packages/ui/src/archive/cards/ProjectStatusCard/ProjectStatusCard.test.tsx
+++ b/packages/ui/src/archive/cards/ProjectStatusCard/ProjectStatusCard.test.tsx
@@ -1,11 +1,47 @@
-import { render } from "@testing-library/react";
+import { Maybe, PhaseType } from "@eden/package-graphql/generated";
 
-import { ProjectStatusCard } from "./";
+import { getProgressFrom } from "./ProjectStatusCard";
 
-describe("ProjectStatusCard", () => {
-  it("renders without throwing", () => {
-    const { container } = render(<ProjectStatusCard />);
+describe("getProgressFrom", () => {
+  type TestCase = [
+    phase: Maybe<PhaseType> | undefined,
+    completedSteps: (
+      | "Applied"
+      | "Invited to Project"
+      | "Application Reviewed"
+      | "Application Accepted"
+    )[]
+  ];
 
-    expect(container).toBeInTheDocument();
+  test.each<TestCase>([
+    [undefined, []],
+    [null, []],
+    [PhaseType.Engaged, ["Applied"]],
+    [PhaseType.Invited, ["Applied", "Invited to Project"]],
+    [
+      PhaseType.Shortlisted,
+      ["Applied", "Invited to Project", "Application Reviewed"],
+    ],
+    [
+      PhaseType.Committed,
+      [
+        "Applied",
+        "Invited to Project",
+        "Application Reviewed",
+        "Application Accepted",
+      ],
+    ],
+  ])("%s -> %O", (phase, completedSteps) => {
+    const result = getProgressFrom(phase);
+
+    for (const step of result) {
+      if (step.completed) {
+        // if completed, should be in the completed steps
+        expect(completedSteps).toContain(step.name);
+      } else {
+        // if incomplete, should not be in the completed steps
+        expect(completedSteps).not.toContain(step.name);
+      }
+    }
   });
 });

--- a/packages/ui/src/archive/cards/ProjectStatusCard/ProjectStatusCard.tsx
+++ b/packages/ui/src/archive/cards/ProjectStatusCard/ProjectStatusCard.tsx
@@ -1,4 +1,8 @@
-import { ProjectMemberType } from "@eden/package-graphql/generated";
+import {
+  Maybe,
+  PhaseType,
+  ProjectMemberType,
+} from "@eden/package-graphql/generated";
 import {
   Avatar,
   Button,
@@ -17,6 +21,32 @@ export interface ProjectStatusCardProps {
   kickoffDateData?: DateCardProps;
 }
 
+export const getProgressFrom = (phase?: Maybe<PhaseType>) => {
+  return [
+    {
+      name: "Applied",
+      completed:
+        phase === "engaged" ||
+        phase === "invited" ||
+        phase === "shortlisted" ||
+        phase === "committed",
+    },
+    {
+      name: "Invited to Project",
+      completed:
+        phase === "invited" || phase === "shortlisted" || phase === "committed",
+    },
+    {
+      name: "Application Reviewed",
+      completed: phase === "shortlisted" || phase === "committed",
+    },
+    {
+      name: "Application Accepted",
+      completed: phase === "committed",
+    },
+  ];
+};
+
 export const ProjectStatusCard: React.FC<ProjectStatusCardProps> = ({
   project,
   roleName,
@@ -24,32 +54,7 @@ export const ProjectStatusCard: React.FC<ProjectStatusCardProps> = ({
 }) => {
   const [cardStatus, setCardStatus] = useState(false);
 
-  const steps = [
-    {
-      name: "Applied",
-      completed:
-        project?.phase === "engaged" ||
-        project?.phase === "invited" ||
-        project?.phase === "shortlisted" ||
-        project?.phase === "committed",
-    },
-    {
-      name: "Invited to Project",
-      completed:
-        project?.phase === "invited" ||
-        project?.phase === "shortlisted" ||
-        project?.phase === "committed",
-    },
-    {
-      name: "Application Reviewed",
-      completed:
-        project?.phase === "shortlisted" || project?.phase === "committed",
-    },
-    {
-      name: "Application Accepted",
-      completed: project?.phase === "committed",
-    },
-  ];
+  const steps = getProgressFrom(project?.phase);
 
   // console.log("project", project);
 


### PR DESCRIPTION
This PR adds the tests mentioned in #672.

Since the component is in `archive`, I'm not even sure it's actually used anywhere but imo it's better to have this than to not have it.