### PR TITLE
add global `IntersectionObserver` mock to jest setup

### DIFF
--- a/packages/config/jest/setup.ts
+++ b/packages/config/jest/setup.ts
@@ -47,3 +47,9 @@ jest.mock("react-chartjs-2", () => ({
   Bar: () => null,
   Radar: () => null,
 }));
+
+window.IntersectionObserver = jest.fn().mockReturnValue({
+  observe: () => null,
+  unobserve: () => null,
+  disconnect: () => null,
+});

--- a/packages/ui/src/modals/ProjectsMatchesModal/ProjectsMatchesModal.test.tsx
+++ b/packages/ui/src/modals/ProjectsMatchesModal/ProjectsMatchesModal.test.tsx
@@ -3,12 +3,6 @@ import userEvent from "@testing-library/user-event";
 
 import { ProjectsMatchesModal } from ".";
 
-window.IntersectionObserver = jest.fn().mockReturnValue({
-  observe: () => null,
-  unobserve: () => null,
-  disconnect: () => null,
-});
-
 test("openModal controls whether modal is rendered", () => {
   const { rerender } = render(<ProjectsMatchesModal openModal={false} />);
 


### PR DESCRIPTION
This PR moves the `IntersectionObserver` mock created in #644 to our global `jest` config package. This means it's now available in all of our tests, which will help us avoid test failures for components using `Dialog` from `@headless-ui/react`.