### PR TITLE
remove prettier eslint plugin and config

### DIFF
--- a/packages/config/.eslintrc.js
+++ b/packages/config/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-  extends: ["next", "prettier", "next/core-web-vitals"],
-  plugins: ["simple-import-sort", "prettier"],
+  extends: ["next", "next/core-web-vitals"],
+  plugins: ["simple-import-sort"],
   settings: {
     next: {
       rootDir: ["apps/*/", "packages/*/"],
@@ -10,7 +10,6 @@ module.exports = {
     "@next/next/no-html-link-for-pages": "off",
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
-    "prettier/prettier": ["error"],
     "no-unused-vars": "error",
     "prefer-const": "error",
     "no-irregular-whitespace": "error",

--- a/packages/config/eslint-preset.js
+++ b/packages/config/eslint-preset.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ["next", "prettier"],
+  extends: ["next"],
   settings: {
     next: {
       rootDir: ["apps/*/", "packages/*/"],

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,8 +12,7 @@
     "clean-windows": "rd /s /q node_modules"
   },
   "dependencies": {
-    "eslint-config-next": "^12.0.3",
-    "eslint-config-prettier": "^8.3.0"
+    "eslint-config-next": "^12.0.3"
   },
   "devDependencies": {
     "@eden/package-tsconfig": "*",
@@ -21,7 +20,6 @@
     "@testing-library/react": "13.3.0",
     "@types/jest": "^28.1.6",
     "eslint": "^8.24.0",
-    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.2",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -12,7 +12,6 @@
     "@apollo/client": "^3.6.9",
     "apollo-utilities": "^1.3.4",
     "eslint-config-next": "^12.0.3",
-    "eslint-config-prettier": "^8.3.0",
     "graphql-ws": "^5.10.1"
   },
   "devDependencies": {
@@ -24,7 +23,6 @@
     "@graphql-codegen/typescript-react-apollo": "3.3.2",
     "cross-fetch": "^3.1.5",
     "eslint": "^8.8.0",
-    "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "typescript": "^4.8.4"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7120,11 +7120,6 @@ eslint-config-next@^12.0.3:
     eslint-plugin-react "^7.31.7"
     eslint-plugin-react-hooks "^4.5.0"
 
-eslint-config-prettier@^8.3.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
-  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
-
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
@@ -7188,13 +7183,6 @@ eslint-plugin-jsx-a11y@^6.5.1:
     language-tags "^1.0.5"
     minimatch "^3.1.2"
     semver "^6.3.0"
-
-eslint-plugin-prettier@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
-  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-react-hooks@^4.5.0:
   version "4.6.0"
@@ -7575,11 +7563,6 @@ fast-deep-equal@^3.0.0, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -11885,13 +11868,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier-plugin-tailwindcss@^0.1.13:
   version "0.1.13"


### PR DESCRIPTION
This PR removes the `eslint-plugin-prettier` and `eslint-config-prettier` packages and related lint configuration.

The reason for this is because `prettier`-related lint rules are _annoying_. Here's an example:

![Kapture 2022-12-06 at 12 44 23](https://user-images.githubusercontent.com/1954752/205985906-8f08062d-8569-4fd9-8e4c-758056953fd0.gif)

Writing a basic component immediately results in 5 lint errors. That's almost as many errors as lines of code! 

And they're not even helpful errors either—for most of us, they're just pure noise. I will never manually format a line of code just because a linter tells me to and I'm pretty sure no one else will either!

(btw, inline errors in the gif are provided by the [Error Lens](https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens) extension for VSCode)

> But `with-heart`, don't we want to protect our codebase from non-formatted code?

Yes, we do! And luckily for us, there are tools that help protect us while being significantly less intrusive.

Conveniently enough, there's already a PR open for adding some of those tools! 😁 

#686 adds `husky` and `lint-staged` which will automatically format code being committed in our local environments, which means we get _nearly_ the same protection without the errors.

I say _nearly_ because technically `husky`/`lint-staged` can be skipped if a user really wants to skip them. So it's possible that someone could intentionally skip them and open a PR with non-formatted code. The likelihood of that is very low though, so I don't think we should worry about it unless it becomes an actual problem we're facing.