### PR TITLE
fix ColorPicker behavior and accessibility

### DIFF
--- a/packages/ui/src/elements/ColorPicker/ColorPicker.stories.tsx
+++ b/packages/ui/src/elements/ColorPicker/ColorPicker.stories.tsx
@@ -1,4 +1,5 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { ComponentMeta } from "@storybook/react";
+import { useState } from "react";
 
 import { ColorPicker } from "./ColorPicker";
 
@@ -8,11 +9,8 @@ export default {
   argTypes: {},
 } as ComponentMeta<typeof ColorPicker>;
 
-const Template: ComponentStory<typeof ColorPicker> = (args) => (
-  <ColorPicker {...args} />
-);
+export const Default = () => {
+  const [value, setValue] = useState("rgb(255,0,0)");
 
-export const Default = Template.bind({});
-Default.args = {
-  onChange: (color) => console.info({ color }),
+  return <ColorPicker onChange={(color) => setValue(color)} value={value} />;
 };

--- a/packages/ui/src/elements/ColorPicker/ColorPicker.test.tsx
+++ b/packages/ui/src/elements/ColorPicker/ColorPicker.test.tsx
@@ -1,11 +1,30 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import { ColorPicker } from "./";
 
-describe("ColorPicker", () => {
-  it("renders without throwing", () => {
-    const { container } = render(<ColorPicker />);
+test("color is controlled", () => {
+  const value = "rgb(255,255,255)";
+  const onChange = jest.fn();
 
-    expect(container).toBeInTheDocument();
+  const { rerender } = render(
+    <ColorPicker value={value} onChange={onChange} />
+  );
+
+  expect(screen.getByLabelText(/project color/i)).toHaveValue("#ffffff");
+
+  // unfortunately `testing-library` doesn't provide a way to interact with
+  // `color` specifically, but we can fire an event that is pretty close to how
+  // the native element would be interacted with in the browser
+  fireEvent.input(screen.getByLabelText(/project color/i), {
+    target: { value: "#000000" },
   });
+
+  // value doesn't change because `onChange` didn't change it
+  expect(value).toEqual("rgb(255,255,255)");
+  // but it was called with the right value
+  expect(onChange).toHaveBeenCalledWith("rgb(0,0,0)");
+
+  // value changes when the prop changes
+  rerender(<ColorPicker value={"rgb(0,0,0)"} onChange={onChange} />);
+  expect(screen.getByLabelText(/project color/i)).toHaveValue("#000000");
 });

--- a/packages/ui/src/elements/ColorPicker/ColorPicker.tsx
+++ b/packages/ui/src/elements/ColorPicker/ColorPicker.tsx
@@ -1,28 +1,10 @@
 import iro from "@jaames/iro";
-import {
-  createRef,
-  FunctionComponent,
-  MutableRefObject,
-  RefObject,
-  useEffect,
-  useRef,
-} from "react";
+import { IroColorPicker } from "@jaames/iro/dist/ColorPicker";
+import { useCallback, useEffect, useRef } from "react";
 
-interface IroColorPicker {
-  // eslint-disable-next-line no-unused-vars
-  on: (action: string, callback: Function) => void;
-  // eslint-disable-next-line no-unused-vars
-  off: (action: string, callback: Function) => void;
-  color: {
-    rgbString: string;
-    // eslint-disable-next-line no-unused-vars
-    set: (value: any) => void;
-    // eslint-disable-next-line no-unused-vars
-    setState: (state: any) => void;
-  };
-}
+import { hexRgb, rgbHex } from "./color";
 
-export interface ColorInputProps {
+export interface ColorPickerProps {
   className?: string;
   value?: string;
   width?: number;
@@ -30,54 +12,63 @@ export interface ColorInputProps {
   onChange?: (color: string) => void;
 }
 
-export const ColorPicker: FunctionComponent<ColorInputProps> = ({
+export const ColorPicker = ({
   width = 200,
   value = "rgb(255, 0, 0)",
-  onChange = () => null,
-}) => {
-  const colorPicker: MutableRefObject<IroColorPicker | null> =
-    useRef<IroColorPicker | null>(null);
-  const el: RefObject<HTMLDivElement> = createRef<HTMLDivElement>();
+  onChange,
+}: ColorPickerProps) => {
+  const colorPickerRef = useRef<IroColorPicker | null>(null);
 
-  useEffect(() => {
-    if (!el.current) {
-      return;
-    }
-    if (!colorPicker.current) {
-      // create a new iro color picker and pass component props to it
-      colorPicker.current = new (iro.ColorPicker as any)(el.current, {
-        width,
-        color: value,
-        layout: [
-          {
-            component: iro.ui.Wheel,
-          },
-        ],
-      });
-      // call onColorChange prop whenever the color changes
-      if (!colorPicker.current) {
+  const onColorChange = useCallback(
+    (color: iro.Color) => {
+      onChange?.(color.rgbString);
+    },
+    [onChange]
+  );
+
+  const elementRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node || colorPickerRef.current) {
         return;
       }
-      colorPicker.current.on("color:change", (color: { rgbString: string }) => {
-        onChange(color.rgbString);
+
+      const colorPicker = iro.ColorPicker(node, {
+        width,
+        color: value,
+        layout: [{ component: iro.ui.Wheel }],
       });
-    } else if (value !== colorPicker.current.color.rgbString) {
-      colorPicker.current.color.set(value);
-    }
 
+      colorPicker.on("color:change", onColorChange);
+      colorPickerRef.current = colorPicker;
+    },
+    [onColorChange, value, width]
+  );
+
+  useEffect(() => {
+    colorPickerRef.current?.on("color:change", onColorChange);
     return () => {
-      if (colorPicker.current) {
-        colorPicker.current.off(
-          "color:change",
-          (color: { rgbString: string }) => {
-            onChange(color.rgbString);
-          }
-        );
-      }
+      colorPickerRef.current?.off("color:change", onColorChange);
     };
+  }, [onColorChange]);
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  useEffect(() => {
+    colorPickerRef.current?.color.set(value);
+  }, [value]);
 
-  return <div ref={el} />;
+  return (
+    <>
+      <div ref={elementRef} />
+      <input
+        className="sr-only"
+        type="color"
+        aria-label="project color"
+        value={rgbHex(value)}
+        onChange={(event) => {
+          const color = hexRgb(event.target.value);
+
+          onChange?.(color);
+        }}
+      />
+    </>
+  );
 };

--- a/packages/ui/src/elements/ColorPicker/color.test.ts
+++ b/packages/ui/src/elements/ColorPicker/color.test.ts
@@ -1,0 +1,21 @@
+import { hexRgb, rgbHex } from "./color";
+
+test("rgbHex", () => {
+  expect(rgbHex("rgb(0,255,0)")).toEqual("#00ff00");
+  expect(rgbHex("rgb(255,0,255)")).toEqual("#ff00ff");
+
+  expect(rgbHex("rgb(0, 255, 0)")).toEqual("#00ff00");
+  expect(rgbHex("rgb(255, 0, 255)")).toEqual("#ff00ff");
+});
+
+describe("hexRgb", () => {
+  test("with 3-digit hex (#fff)", () => {
+    expect(hexRgb("#fff")).toEqual("rgb(255,255,255)");
+    expect(hexRgb("#f0f")).toEqual("rgb(255,0,255)");
+  });
+
+  test("with 6-digit hex", () => {
+    expect(hexRgb("#ff00ff")).toEqual("rgb(255,0,255)");
+    expect(hexRgb("#00ff00")).toEqual("rgb(0,255,0)");
+  });
+});

--- a/packages/ui/src/elements/ColorPicker/color.ts
+++ b/packages/ui/src/elements/ColorPicker/color.ts
@@ -1,0 +1,42 @@
+// Thanks to github.com/sindresorhus and the `hex-rgb`+`rgb-hex` libraries for
+// inspiration and some of the code here
+
+const rgbRe = /rgb\((\d{1,3})[, ]*(\d{1,3})[, ]+(\d{1,3})\)/;
+
+/**
+ * Converts an `rgb` string (`rgb(255, 120, 255)`) to hex
+ */
+export const rgbHex = (rgb: string) => {
+  const match = rgb.match(rgbRe)!;
+  const [, r, g, b] = [...match];
+
+  const hex = (
+    parseInt(b) |
+    (parseInt(g) << 8) |
+    (parseInt(r) << 16) |
+    (1 << 24)
+  )
+    .toString(16)
+    .slice(1);
+
+  return `#${hex}`;
+};
+
+/**
+ * Converts a hex string to an `rgb` string
+ */
+export const hexRgb = (hex: string) => {
+  // remove the '#' prefix
+  hex = hex.replace(/^#/, "");
+
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  }
+
+  const number = Number.parseInt(hex, 16);
+  const red = number >> 16;
+  const green = (number >> 8) & 255;
+  const blue = number & 255;
+
+  return `rgb(${red},${green},${blue})`;
+};


### PR DESCRIPTION
fixes #703 by adding an `input type="color"` specifically for screenreaders

this means we can use the `iro` colorpicker and the `input` at the same time without them interfering with each other. 

it _also_ means we can test the colorpicker using `testing-library`!