### PR TITLE
remove redundent MockedProvider in storybook files

### DIFF
--- a/packages/ui/src/archive/modals/SkillMatchModal/SkillMatchModal.stories.tsx
+++ b/packages/ui/src/archive/modals/SkillMatchModal/SkillMatchModal.stories.tsx
@@ -1,3 +1,4 @@
+import { getSkillsPercentageTypeMockArray } from "@eden/package-mock";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { SkillMatchModal } from "./SkillMatchModal";
@@ -22,30 +23,5 @@ Default.args = {
   projectHr: 25,
   yourHr: 15,
   matchingPercentage: 81,
-  chartData: [
-    {
-      name: "Web Design",
-      percentage: 60,
-    },
-    {
-      name: "Blockchain",
-      percentage: 95,
-    },
-    {
-      name: "Agile Dev",
-      percentage: 55,
-    },
-    {
-      name: "Business",
-      percentage: 70,
-    },
-    {
-      name: "Marketing",
-      percentage: 41,
-    },
-    {
-      name: "Sales",
-      percentage: 48,
-    },
-  ],
+  chartData: getSkillsPercentageTypeMockArray(5),
 };

--- a/packages/ui/src/archive/modals/SkillsCategoryModal/SkillsCategoryModal.stories.tsx
+++ b/packages/ui/src/archive/modals/SkillsCategoryModal/SkillsCategoryModal.stories.tsx
@@ -1,5 +1,4 @@
-import { MockedProvider } from "@apollo/client/testing";
-import { FIND_ALL_CATEGORIES } from "@eden/package-graphql";
+import { FIND_ALL_MAIN_CATEGORIES } from "@eden/package-graphql";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { SkillsCategoryModal } from "./SkillsCategoryModal";
@@ -21,15 +20,14 @@ Default.args = {
 
 Default.parameters = {
   apolloClient: {
-    MockedProvider,
     mocks: [
       {
         request: {
-          query: FIND_ALL_CATEGORIES,
+          query: FIND_ALL_MAIN_CATEGORIES,
         },
         result: {
           data: {
-            findSkillSubCategories: [
+            findSkillCategories: [
               {
                 _id: "63098c32b003e10004f99c8e",
                 name: "Web Design and Development",

--- a/packages/ui/src/archive/modals/SkillsModal/SkillsModal.stories.tsx
+++ b/packages/ui/src/archive/modals/SkillsModal/SkillsModal.stories.tsx
@@ -1,5 +1,3 @@
-import { MockedProvider } from "@apollo/client/testing";
-import { FIND_ALL_CATEGORIES } from "@eden/package-graphql";
 import { getSkillRoleTypeMockArray } from "@eden/package-mock";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
@@ -24,37 +22,4 @@ Default.args = {
   },
 };
 
-Default.parameters = {
-  apolloClient: {
-    MockedProvider,
-    mocks: [
-      {
-        request: {
-          query: FIND_ALL_CATEGORIES,
-        },
-        result: {
-          data: {
-            findSkillSubCategories: [
-              {
-                _id: "63098c32b003e10004f99c8e",
-                name: "Web Design and Development",
-              },
-              {
-                _id: "63098cf8b003e10004f9a94e",
-                name: "Scripting Languages",
-              },
-              {
-                _id: "63098cfbb003e10004f9a9ed",
-                name: "Computer Science",
-              },
-              {
-                _id: "63098d00b003e10004f9aa15",
-                name: "C and C++",
-              },
-            ],
-          },
-        },
-      },
-    ],
-  },
-};
+Default.parameters = {};

--- a/packages/ui/src/archive/modals/SkillsOnCategoryModal/SkillsOnCategoryModal.stories.tsx
+++ b/packages/ui/src/archive/modals/SkillsOnCategoryModal/SkillsOnCategoryModal.stories.tsx
@@ -1,5 +1,4 @@
-import { MockedProvider } from "@apollo/client/testing";
-import { FIND_ALL_CATEGORIES } from "@eden/package-graphql";
+import { getSkillRoleTypeMockArray } from "@eden/package-mock";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { SkillsOnCategoryModal } from "./SkillsOnCategoryModal";
@@ -16,87 +15,9 @@ const Template: ComponentStory<typeof SkillsOnCategoryModal> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  skills: [
-    {
-      skillData: {
-        _id: "1",
-        name: "skill1",
-      },
-    },
-    {
-      skillData: {
-        _id: "2",
-        name: "skill2",
-      },
-    },
-    {
-      skillData: {
-        _id: "3",
-        name: "skill3",
-      },
-    },
-    {
-      skillData: {
-        _id: "4",
-        name: "skill4",
-      },
-    },
-    {
-      skillData: {
-        _id: "5",
-        name: "skill5",
-      },
-    },
-    {
-      skillData: {
-        _id: "6",
-        name: "skill6",
-      },
-    },
-    {
-      skillData: {
-        _id: "7",
-        name: "skill7",
-      },
-    },
-  ],
+  skills: getSkillRoleTypeMockArray(6),
   isOpen: true,
   handelAddSkills() {
     console.log("SkillsOnCategoryModal HandelAddSkills");
-  },
-};
-
-Default.parameters = {
-  apolloClient: {
-    MockedProvider,
-    mocks: [
-      {
-        request: {
-          query: FIND_ALL_CATEGORIES,
-        },
-        result: {
-          data: {
-            findSkillSubCategories: [
-              {
-                _id: "63098c32b003e10004f99c8e",
-                name: "Web Design and Development",
-              },
-              {
-                _id: "63098cf8b003e10004f9a94e",
-                name: "Scripting Languages",
-              },
-              {
-                _id: "63098cfbb003e10004f9a9ed",
-                name: "Computer Science",
-              },
-              {
-                _id: "63098d00b003e10004f9aa15",
-                name: "C and C++",
-              },
-            ],
-          },
-        },
-      },
-    ],
   },
 };

--- a/packages/ui/src/archive/modals/SkillsSubcategoryModal/SkillsSubcategoryModal.stories.tsx
+++ b/packages/ui/src/archive/modals/SkillsSubcategoryModal/SkillsSubcategoryModal.stories.tsx
@@ -1,4 +1,3 @@
-import { MockedProvider } from "@apollo/client/testing";
 import { FIND_ALL_CATEGORIES } from "@eden/package-graphql";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
@@ -21,7 +20,6 @@ Default.args = {
 
 Default.parameters = {
   apolloClient: {
-    MockedProvider,
     mocks: [
       {
         request: {

--- a/packages/ui/src/components/CategoryExpandable/CategoryExpandable.stories.tsx
+++ b/packages/ui/src/components/CategoryExpandable/CategoryExpandable.stories.tsx
@@ -1,4 +1,3 @@
-import { MockedProvider } from "@apollo/client/testing";
 import { FIND_SUBCATEGORIES_OF_CATEGORIES } from "@eden/package-graphql";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
@@ -33,7 +32,6 @@ Default.args = {
 
 Default.parameters = {
   apolloClient: {
-    MockedProvider,
     mocks: [
       {
         request: {

--- a/packages/ui/src/components/CategorySearchSkill/CategorySearchSkill.stories.tsx
+++ b/packages/ui/src/components/CategorySearchSkill/CategorySearchSkill.stories.tsx
@@ -1,4 +1,3 @@
-import { MockedProvider } from "@apollo/client/testing";
 import { FIND_ALL_MAIN_CATEGORIES } from "@eden/package-graphql";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { useState } from "react";
@@ -38,7 +37,6 @@ export const Default = Template.bind({});
 
 Default.parameters = {
   apolloClient: {
-    MockedProvider,
     mocks: [
       {
         request: {

--- a/packages/ui/src/components/SearchSkill/SearchSkill.stories.tsx
+++ b/packages/ui/src/components/SearchSkill/SearchSkill.stories.tsx
@@ -1,4 +1,3 @@
-import { MockedProvider } from "@apollo/client/testing";
 import { FIND_ALL_CATEGORIES } from "@eden/package-graphql";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import { useState } from "react";
@@ -38,7 +37,6 @@ export const Default = Template.bind({});
 
 Default.parameters = {
   apolloClient: {
-    MockedProvider,
     mocks: [
       {
         request: {


### PR DESCRIPTION
This PR removes `import { MockedProvider } from "@apollo/client/testing";` from various storybook files.  These were redundant because a global provider for storybook was created with PR #688  