### PR TITLE
fix: auth error

### DIFF
--- a/packages/graphql/apollo-client.ts
+++ b/packages/graphql/apollo-client.ts
@@ -14,7 +14,6 @@ import { RetryLink } from "@apollo/client/link/retry";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { createClient } from "graphql-ws";
 import { getMainDefinition } from "@apollo/client/utilities";
-import { signOut } from "next-auth/react";
 
 import jwt_decode from "jwt-decode";
 
@@ -69,7 +68,6 @@ const edenLink = new ApolloLink((operation, forward) => {
       })
 
       .catch(() => {
-        signOut();
         return toPromise(forward(operation));
       })
   );

--- a/packages/graphql/apollo-client.ts
+++ b/packages/graphql/apollo-client.ts
@@ -14,6 +14,7 @@ import { RetryLink } from "@apollo/client/link/retry";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { createClient } from "graphql-ws";
 import { getMainDefinition } from "@apollo/client/utilities";
+import { signOut } from "next-auth/react";
 
 import jwt_decode from "jwt-decode";
 
@@ -68,6 +69,7 @@ const edenLink = new ApolloLink((operation, forward) => {
       })
 
       .catch(() => {
+        signOut();
         return toPromise(forward(operation));
       })
   );

--- a/packages/ui/src/components/OpenPositions/OpenPositions.tsx
+++ b/packages/ui/src/components/OpenPositions/OpenPositions.tsx
@@ -139,8 +139,7 @@ const PositionExpanded = ({
   tabs: string[];
   activeItem: MatchProjectRoles;
   activeTab: number;
-  // eslint-disable-next-line no-unused-vars
-  setActiveTab: (activeTab: number) => void;
+  setActiveTab: React.Dispatch<React.SetStateAction<number>>;
 }) => {
   const { currentUser } = useContext(UserContext);
   const [applying, setApplying] = useState(false);

--- a/packages/ui/src/containers/ViewProjectContainer/ViewProjectContainer.tsx
+++ b/packages/ui/src/containers/ViewProjectContainer/ViewProjectContainer.tsx
@@ -219,20 +219,6 @@ export const ViewProjectContainer = ({
                 </div>
 
                 <div className="mb-3 grid grid-cols-3 gap-4">
-                  {/* <div className="col-span-1">
-                    <div className="text-soilGray/100 font-medium uppercase tracking-wide">
-                      💯 Expectations
-                    </div>
-                    <div className="text-sm">
-                      {activeRole?.expectations?.map(
-                        (obj: string, index: number) => (
-                          <li key={index} className="overflow-auto">
-                            {obj}
-                          </li>
-                        )
-                      )}
-                    </div>
-                  </div> */}
                   <div className="col-span-2">
                     <div className="text-soilGray/100 my-1 font-medium uppercase tracking-wide">
                       🦜 Benefits


### PR DESCRIPTION
This PR fixes the error when a user's discord token expires.

if the discord token is expired when making a fetch to the Eden API for auth token, the user is forced signed out.  When the user logs back in, the user will get a fresh discord and Eden token