### PR TITLE
remove serverselect from userContext

### DIFF
--- a/apps/alpha/pages/admin/create-party/index.tsx
+++ b/apps/alpha/pages/admin/create-party/index.tsx
@@ -8,6 +8,7 @@ import {
   GridItemThree,
   GridLayout,
   SEO,
+  ServerSelector,
   TextField,
   TextHeading2,
   TextHeading3,
@@ -27,7 +28,8 @@ const CREATE_ROOM = gql`
 `;
 
 const DiscoverPage: NextPageWithLayout = () => {
-  const { currentUser, selectedServer } = useContext(UserContext);
+  const { currentUser } = useContext(UserContext);
+  const [selectedServer, setSelectedServer] = useState<ServerTemplate>({});
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -80,6 +82,17 @@ const DiscoverPage: NextPageWithLayout = () => {
             <div className={`grid grid-cols-2`}>
               <div className={`col-span-1`}>
                 <TextHeading2>Create a Room</TextHeading2>
+                <div className={``}>
+                  <div
+                    className={`font-Inter my-auto font-medium text-gray-700`}
+                  >
+                    Select a Discord Server to Connect in
+                  </div>
+                  <ServerSelector
+                    compareServerID={[]}
+                    onChangeServer={(val) => setSelectedServer(val)}
+                  />
+                </div>
                 <Card>
                   <TextField
                     label={`Room Name`}
@@ -149,6 +162,7 @@ DiscoverPage.getLayout = (page) => (
 
 export default DiscoverPage;
 
+import { ServerTemplate } from "@eden/package-graphql/generated";
 import { IncomingMessage, ServerResponse } from "http";
 import { getSession } from "next-auth/react";
 

--- a/apps/alpha/pages/api/discord/createForumPost.ts
+++ b/apps/alpha/pages/api/discord/createForumPost.ts
@@ -34,6 +34,7 @@ export default async (
     const {
       message,
       embedMessage,
+      tagName,
       senderAvatarURL,
       senderName,
       channelId,
@@ -62,7 +63,7 @@ export default async (
     // Find tag --- `Chat` ID, used in creating post in forum
     // Only post with specific tags can be captured by the bot
     const tags = forumResponse.data.available_tags.filter(
-      (tag) => tag.name === "Chat"
+      (tag) => tag.name === tagName
     );
 
     if (tags.length === 0) {

--- a/apps/alpha/pages/test/discover_test/index.tsx
+++ b/apps/alpha/pages/test/discover_test/index.tsx
@@ -38,7 +38,6 @@ const DiscoverPage: NextPageWithLayout = () => {
     variables: {
       fields: {
         nodesID: nodesID,
-        // TODO: change to selectedServer
         serverID: selectedServerID,
       },
     },

--- a/apps/alpha/types/type.ts
+++ b/apps/alpha/types/type.ts
@@ -32,6 +32,7 @@ export interface CreateThreadApiRequestBody {
   senderName: string;
   senderAvatarURL: string;
   channelId: string;
+  tagName: string;
   threadName: string;
   ThreadAutoArchiveDuration: ThreadAutoArchiveDuration;
 }

--- a/apps/alpha/types/type.ts
+++ b/apps/alpha/types/type.ts
@@ -32,7 +32,7 @@ export interface CreateThreadApiRequestBody {
   senderName: string;
   senderAvatarURL: string;
   channelId: string;
-  tagName: string;
+  tagName?: string;
   threadName: string;
   ThreadAutoArchiveDuration: ThreadAutoArchiveDuration;
 }

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -53,15 +53,9 @@ export const parameters = {
 
 const injectContext: UserContextType = {
   currentUser: getMember(),
-  setCurrentUser: (user: Members) => {
-    console.log("setCurrentUser", user);
-    // injectContext.currentUser = user;
-  },
   refechProfile: () => {},
   memberServers: findServers,
   memberServerIDs: findServers.map((server) => server._id) as string[],
-  selectedServer: null,
-  setSelectedServer: () => {},
   selectedServerID: [],
   setSelectedServerID: () => {},
 };

--- a/apps/web/pages/discover/index.tsx
+++ b/apps/web/pages/discover/index.tsx
@@ -36,7 +36,6 @@ import type { NextPageWithLayout } from "../_app";
 
 const DiscoverPage: NextPageWithLayout = () => {
   const router = useRouter();
-  // const { selectedServer, memberServerIDs } = useContext(UserContext);
   const { setOpenModal } = useContext(DiscoverContext);
   const { selectedServerID } = useContext(UserContext);
   const [nodesID, setNodesID] = useState<string[] | null>(null);

--- a/apps/web/types/type.ts
+++ b/apps/web/types/type.ts
@@ -34,7 +34,7 @@ export interface CreateMessageApiRequestBody {
   senderName?: string;
   senderAvatarURL?: string;
   channelId?: string;
-  tagName: string;
+  tagName?: string;
   threadName?: string;
   ThreadAutoArchiveDuration?: ThreadAutoArchiveDuration;
 }

--- a/apps/web/types/type.ts
+++ b/apps/web/types/type.ts
@@ -34,6 +34,7 @@ export interface CreateMessageApiRequestBody {
   senderName?: string;
   senderAvatarURL?: string;
   channelId?: string;
+  tagName: string;
   threadName?: string;
   ThreadAutoArchiveDuration?: ThreadAutoArchiveDuration;
 }

--- a/packages/context/src/UserContext/UserContext.tsx
+++ b/packages/context/src/UserContext/UserContext.tsx
@@ -1,18 +1,11 @@
-import {
-  Maybe,
-  Members,
-  ServerTemplate,
-} from "@eden/package-graphql/generated";
+import { Members, ServerTemplate } from "@eden/package-graphql/generated";
 import { createContext, Dispatch } from "react";
 
 export interface UserContextType {
   currentUser?: Members;
-  setCurrentUser: Dispatch<Members>;
   refechProfile: () => void;
   memberServers: ServerTemplate[];
   memberServerIDs: string[];
-  selectedServer: Maybe<ServerTemplate>;
-  setSelectedServer: Dispatch<string>;
   selectedServerID: string[];
   setSelectedServerID: Dispatch<string[]>;
 }
@@ -20,14 +13,9 @@ export interface UserContextType {
 export const UserContext = createContext<UserContextType>({
   currentUser: undefined,
   // eslint-disable-next-line no-empty-function
-  setCurrentUser: () => {},
-  // eslint-disable-next-line no-empty-function
   refechProfile: () => {},
   memberServers: [],
   memberServerIDs: [],
-  selectedServer: {},
-  // eslint-disable-next-line no-empty-function
-  setSelectedServer: () => {},
   selectedServerID: [],
   // eslint-disable-next-line no-empty-function
   setSelectedServerID: () => {},

--- a/packages/context/src/UserContext/UserProvider.tsx
+++ b/packages/context/src/UserContext/UserProvider.tsx
@@ -1,6 +1,6 @@
 import { gql, useQuery, useSubscription } from "@apollo/client";
 import { FIND_CURRENTUSER, FIND_CURRENTUSER_SUB } from "@eden/package-graphql";
-import { Members, ServerTemplate } from "@eden/package-graphql/generated";
+import { ServerTemplate } from "@eden/package-graphql/generated";
 import { useSession } from "next-auth/react";
 import React, { useEffect, useState } from "react";
 
@@ -16,6 +16,7 @@ export const FIND_SERVERS = gql`
       serverType
       channel {
         chatID
+        # forumID
       }
     }
   }
@@ -31,7 +32,6 @@ export const UserProvider = ({ children }: UserProviderProps) => {
   const { id } = session?.user || { id: null };
 
   const [memberServers, setMemberServers] = useState<ServerTemplate[]>([]);
-  const [selectedServer, setSelectedServer] = useState<any>(null);
   const [selectedServerID, setSelectedServerID] = useState<string[]>([]);
   const [memberServerIDs, setMemberServerIDs] = useState<string[]>([]);
 
@@ -74,7 +74,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       setMemberServers([...data.findServers]);
-      setSelectedServer(data.findServers[0]);
+      // setSelectedServer(data.findServers[0]);
     },
   });
 
@@ -103,15 +103,9 @@ export const UserProvider = ({ children }: UserProviderProps) => {
 
   const injectContext = {
     currentUser: dataMember?.findMember || undefined,
-    setCurrentUser: (user: Members) => {
-      console.log("setCurrentUser", user);
-      // injectContext.currentUser = user;
-    },
     refechProfile: refechProfile,
     memberServers,
     memberServerIDs,
-    selectedServer,
-    setSelectedServer,
     selectedServerID,
     setSelectedServerID,
   };

--- a/packages/ui/src/archive/containers/ShortlistModalContainerTest/ShortlistModalContainerTest.tsx
+++ b/packages/ui/src/archive/containers/ShortlistModalContainerTest/ShortlistModalContainerTest.tsx
@@ -60,7 +60,7 @@ export const ShortlistModalContainerTest =
       selectedCategories,
       setSelectedCategories,
     } = useContext(LaunchProjectContext);
-    const { currentUser, selectedServer } = useContext(UserContext);
+    const { currentUser } = useContext(UserContext);
 
     const [updateProject, {}] = useMutation(UPDATE_PROJECT, {
       onCompleted({ updateProject }: Mutation) {
@@ -80,7 +80,8 @@ export const ShortlistModalContainerTest =
               descriptionOneLine: project?.descriptionOneLine,
               emoji: project?.emoji,
               champion: currentUser?._id,
-              serverID: selectedServer?._id,
+              // needs a selected server id, previous selected server context is deprecated, server selection is now done locally in the component
+              // serverID: selectedServer?._id,
               role: project?.role?.map((role) => ({
                 title: role?.title,
                 description: role?.description,

--- a/packages/ui/src/components/SendMessageToChampion/SendMessageToChampion.tsx
+++ b/packages/ui/src/components/SendMessageToChampion/SendMessageToChampion.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { gql, useMutation } from "@apollo/client";
 import { UserContext } from "@eden/package-context";
 import {
@@ -7,11 +6,13 @@ import {
   MutationAddNewChatArgs,
   Project,
   RoleType,
+  ServerTemplate,
 } from "@eden/package-graphql/generated";
 import {
   Avatar,
   Button,
   Loading,
+  ServerSelector,
   TextArea,
   TextHeading3,
 } from "@eden/package-ui";
@@ -56,27 +57,26 @@ export const SendMessageToChampion = ({
   // console.log("role", role);
   // console.log("member", member);
 
-  const { currentUser, selectedServer } = useContext(UserContext);
+  const { currentUser } = useContext(UserContext);
   const [message, setMessage] = useState("");
   const [sendingMessage, setSendingMessage] = useState(false);
   const [isMessageSent, setIsMessageSent] = useState(false);
 
+  const [selectedServer, setSelectedServer] = useState<ServerTemplate>({});
+
   const [addNewChat] = useMutation<any, MutationAddNewChatArgs>(ADD_NEW_CHAT);
 
-  const [changeTeamMember_Phase_Project, {}] = useMutation(
-    SET_APPLY_TO_PROJECT,
-    {
-      onCompleted: () => {
-        toast.success("success");
-        setTimeout(() => {
-          setSendingMessage(false);
-        }, 1000);
-      },
-      onError: (error) => {
-        toast.error(error.message);
-      },
-    }
-  );
+  const [changeTeamMemberPhaseProject, {}] = useMutation(SET_APPLY_TO_PROJECT, {
+    onCompleted: () => {
+      toast.success("success");
+      setTimeout(() => {
+        setSendingMessage(false);
+      }, 1000);
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
 
   const createThread = async (body: CreateThreadApiRequestBody) => {
     const response = await fetch(encodeURI("/api/discord/createThread"), {
@@ -161,7 +161,7 @@ export const SendMessageToChampion = ({
     } finally {
       setIsMessageSent(true);
       if (project?._id && member?._id && role?._id) {
-        changeTeamMember_Phase_Project({
+        changeTeamMemberPhaseProject({
           variables: {
             fields: {
               projectID: project?._id,
@@ -198,6 +198,17 @@ export const SendMessageToChampion = ({
                   Send message to @{member?.discordName} about the {role?.title}{" "}
                   Role
                 </TextHeading3>
+                <div className={`my-4 md:mr-28 md:flex md:justify-between`}>
+                  <div
+                    className={`font-Inter my-auto font-medium text-gray-700`}
+                  >
+                    Select a Discord Server to Connect in
+                  </div>
+                  <ServerSelector
+                    compareServerID={project?.serverID || []}
+                    onChangeServer={(val) => setSelectedServer(val)}
+                  />
+                </div>
                 <div className="flex items-center ">
                   <Avatar
                     src={currentUser?.discordAvatar || ""}

--- a/packages/ui/src/containers/CreateProjectContainer/CreateProjectContainer.tsx
+++ b/packages/ui/src/containers/CreateProjectContainer/CreateProjectContainer.tsx
@@ -161,7 +161,7 @@ export const CreateProjectContainer = ({
     setSubmitting(true);
 
     if (state?._id) {
-      console.log("state", state);
+      // console.log("state", state);
       updateProject({
         variables: {
           fields: {

--- a/packages/ui/src/selectors/ServerSelector/ServerSelector.tsx
+++ b/packages/ui/src/selectors/ServerSelector/ServerSelector.tsx
@@ -23,17 +23,17 @@ export const ServerSelector = ({
   compareServerID,
   onChangeString,
   onChangeServer,
-  btnBGcolor = "bg-gray-200",
+  btnBGcolor = "bg-gray-50",
 }: IServerSelectorProps) => {
   const { memberServers } = useContext(UserContext);
   const [availableServers, setAvailableServers] = useState<ServerTemplate[]>(
-    memberServers || []
+    []
   );
 
   const [selected, setSelected] = useState<ServerTemplate>({});
 
   const btnClasses = clsx(
-    "relative flex justify-between items-center border border-gray-300 text-center cursor-pointer rounded-2xl py-1 px-3 shadow-lg hover:shadow-sm hover:border-gray-500 focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-green-300 sm:text-sm",
+    "relative flex justify-between items-center border border-gray-300 text-center cursor-pointer rounded-2xl py-1 px-3 shadow hover:shadow-sm hover:border-gray-400 focus:outline-none focus-visible:border-indigo-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-green-300 sm:text-sm",
     btnBGcolor,
     {
       "border-green-500": isEmpty(selected),
@@ -58,14 +58,16 @@ export const ServerSelector = ({
   }, [value]);
 
   useEffect(() => {
-    if (compareServerID) {
+    if (compareServerID && compareServerID.length > 0) {
       const serverList = memberServers?.filter((item) =>
         compareServerID.includes(item._id as string)
       ) as ServerTemplate[];
 
       setAvailableServers(serverList);
+    } else {
+      setAvailableServers(memberServers);
     }
-  }, [compareServerID]);
+  }, [compareServerID, memberServers]);
 
   return (
     <Listbox

--- a/packages/ui/src/test/DiscordCreateGardenTeam/DiscordCreateGardenTeam.tsx
+++ b/packages/ui/src/test/DiscordCreateGardenTeam/DiscordCreateGardenTeam.tsx
@@ -1,6 +1,6 @@
 import { gql, useMutation } from "@apollo/client";
 import { UserContext } from "@eden/package-context";
-import { Mutation } from "@eden/package-graphql/generated";
+import { Mutation, ServerTemplate } from "@eden/package-graphql/generated";
 import {
   Avatar,
   Button,
@@ -8,6 +8,7 @@ import {
   CheckBox,
   Dropdown,
   Loading,
+  ServerSelector,
   TextField,
   TextHeading3,
 } from "@eden/package-ui";
@@ -52,7 +53,8 @@ const findChannels = async (guildId: string) => {
 export interface IDiscordCreateGardenTeamProps {}
 
 export const DiscordCreateGardenTeam = ({}: IDiscordCreateGardenTeamProps) => {
-  const { currentUser, selectedServer } = useContext(UserContext);
+  const { currentUser } = useContext(UserContext);
+  const [selectedServer, setSelectedServer] = useState<ServerTemplate>({});
   const [channels, setChannels] = useState<any>(null);
   const [chatChannels, setChatChannels] = useState<any>(null);
   const [forumChannels, setForumChannels] = useState<any>(null);
@@ -180,6 +182,16 @@ export const DiscordCreateGardenTeam = ({}: IDiscordCreateGardenTeamProps) => {
   return (
     <Card shadow className={"bg-white p-4"}>
       <TextHeading3>Create Garden Team</TextHeading3>
+      <div className={`my-4 md:mr-28 md:flex md:justify-between`}>
+        <div className={`font-Inter my-auto font-medium text-gray-700`}>
+          Select a Discord Server to Connect in
+        </div>
+        <ServerSelector
+          compareServerID={[]}
+          onChangeServer={(val) => setSelectedServer(val)}
+        />
+      </div>
+
       {!selectedServer?._id ? (
         <div
           className={`my-8 w-full text-center text-3xl font-medium uppercase text-zinc-700`}

--- a/packages/ui/src/test/DiscordThreadChat/DiscordThreadChat.tsx
+++ b/packages/ui/src/test/DiscordThreadChat/DiscordThreadChat.tsx
@@ -1,8 +1,10 @@
 import { UserContext } from "@eden/package-context";
+import { ServerTemplate } from "@eden/package-graphql/generated";
 import {
   Button,
   Card,
   Dropdown,
+  ServerSelector,
   TextArea,
   TextHeading3,
 } from "@eden/package-ui";
@@ -50,9 +52,10 @@ const createThread = async (body: CreateThreadApiRequestBody) => {
 export interface IDiscordThreadChatProps {}
 
 export const DiscordThreadChat = ({}: IDiscordThreadChatProps) => {
-  const { selectedServer, currentUser } = useContext(UserContext);
+  const { currentUser } = useContext(UserContext);
   const [channels, setChannels] = useState<any>(null);
   const [selectedChannel, setSelectedChannel] = useState<any>(null);
+  const [selectedServer, setSelectedServer] = useState<ServerTemplate>({});
 
   const [message, setMessage] = useState("");
   const [sendingMessage, setSendingMessage] = useState(false);
@@ -112,6 +115,16 @@ export const DiscordThreadChat = ({}: IDiscordThreadChatProps) => {
           placeholder="Select a chat channel"
         />
       )}
+
+      <div className={`my-4 md:mr-28 md:flex md:justify-between`}>
+        <div className={`font-Inter my-auto font-medium text-gray-700`}>
+          Select a Discord Server to Connect in
+        </div>
+        <ServerSelector
+          compareServerID={[]}
+          onChangeServer={(val) => setSelectedServer(val)}
+        />
+      </div>
 
       {selectedChannel && (
         <div>

--- a/packages/ui/src/test/DiscordThreadForum/DiscordThreadForum.tsx
+++ b/packages/ui/src/test/DiscordThreadForum/DiscordThreadForum.tsx
@@ -1,9 +1,11 @@
 import { UserContext } from "@eden/package-context";
+import { ServerTemplate } from "@eden/package-graphql/generated";
 import {
   Button,
   Card,
   Dropdown,
   Loading,
+  ServerSelector,
   TextArea,
   TextHeading3,
 } from "@eden/package-ui";
@@ -53,9 +55,11 @@ const createThread = async (body: CreateThreadApiRequestBody) => {
 export interface IDiscordThreadForumProps {}
 
 export const DiscordThreadForum = ({}: IDiscordThreadForumProps) => {
-  const { selectedServer, currentUser } = useContext(UserContext);
+  const { currentUser } = useContext(UserContext);
   const [channels, setChannels] = useState<any>(null);
   const [selectedChannel, setSelectedChannel] = useState<any>(null);
+  const [selectedServer, setSelectedServer] = useState<ServerTemplate>({});
+  const [selectTag, setSelectTag] = useState<any>(null);
 
   const [message, setMessage] = useState("");
   const [sendingMessage, setSendingMessage] = useState(false);
@@ -72,11 +76,19 @@ export const DiscordThreadForum = ({}: IDiscordThreadForumProps) => {
             filteredChannels.push(channel);
           }
         });
+        // console.log("filteredChannels", filteredChannels);
         setChannels(filteredChannels);
+
         // setChannels(response.channels);
       });
     }
   }, [selectedServer]);
+
+  useEffect(() => {
+    if (selectedChannel) {
+      console.log("selectedChannel", selectedChannel);
+    }
+  }, [selectedChannel]);
 
   const embededMessage = `
     Message from ${currentUser?.discordName}:
@@ -86,9 +98,9 @@ export const DiscordThreadForum = ({}: IDiscordThreadForumProps) => {
   const handleSendMessage = async () => {
     setSendingMessage(true);
     console.log("selectedChannel", selectedChannel);
-    console.log(selectedChannel.id);
     await createThread({
       message: `<@${currentUser?._id}>`,
+      tagName: selectTag.name,
       embedMessage: embededMessage,
       senderAvatarURL: currentUser?.discordAvatar!,
       senderName: `${currentUser?.discordName} - says hi!`,
@@ -105,6 +117,16 @@ export const DiscordThreadForum = ({}: IDiscordThreadForumProps) => {
   return (
     <Card shadow className={"bg-white p-4"}>
       <TextHeading3>Create a thread in any FORUM channel </TextHeading3>
+
+      <div className={`my-4 md:mr-28 md:flex md:justify-between`}>
+        <div className={`font-Inter my-auto font-medium text-gray-700`}>
+          Select a Discord Server to Connect in
+        </div>
+        <ServerSelector
+          compareServerID={[]}
+          onChangeServer={(val) => setSelectedServer(val)}
+        />
+      </div>
       {!selectedServer?._id ? (
         <div
           className={`my-8 w-full text-center text-3xl font-medium uppercase text-zinc-700`}
@@ -118,6 +140,12 @@ export const DiscordThreadForum = ({}: IDiscordThreadForumProps) => {
             items={channels}
             onSelect={(value) => setSelectedChannel(value)}
             placeholder="Select a forum channel"
+          />
+          <Dropdown
+            label={`Select a channel`}
+            items={selectedChannel?.available_tags}
+            onSelect={(value) => setSelectTag(value)}
+            placeholder="Select a tag"
           />
         </div>
       )}

--- a/packages/ui/types/type.ts
+++ b/packages/ui/types/type.ts
@@ -32,6 +32,7 @@ export interface CreateThreadApiRequestBody {
   senderName: string;
   senderAvatarURL: string;
   channelId: string;
+  tagName?: string;
   threadName: string;
   ThreadAutoArchiveDuration: ThreadAutoArchiveDuration;
 }


### PR DESCRIPTION
This PR removes unused select server state from the `userContext` 

selecting the server is done locally closer to the mutation instead of globally

globally selection of ids `selectedServerID` is used for querying