### PR TITLE
A more modular component 

### DIFF
--- a/apps/alpha/pages/test/gpt-autocomplete/index.tsx
+++ b/apps/alpha/pages/test/gpt-autocomplete/index.tsx
@@ -9,12 +9,15 @@ import {
 import { NextPageWithLayout } from "../../_app";
 
 const TestPage: NextPageWithLayout = () => {
+  const autocomplete =
+    'I want you to act as a text extension assistant. Do not edit or change the sentences I give you in any way. I give you sentences and you return those sentences unedited with a continuation to those sentences. \nExample: \nI write: A plumber is a tradesperson who specializes in installing and maintaining systems used for water, sewage and drainage. They are responsible for installing, repairing and maintaining pipes, fixtures and other plumbing equipment.\nYou respond with:  A plumber is a tradesperson who specializes in installing and maintaining systems used for water, sewage and drainage. They are responsible for installing, repairing and maintaining pipes, fixtures and other plumbing equipment.   Plumbers also inspect structures to identify any potential problems, such as clogged drains, leaking pipes and faulty water heaters. In addition, they install appliances such as dishwashers and water heaters, and may be asked to perform basic carpentry work to install kitchen and bathroom cabinets.\nI write: Today was a crazy day in the lab, instruments were not working and our computer system went down. Everyone was scrambling to find a solution, with no luck. \nYou respond with: Today was a crazy day in the lab, instruments were not working and our computer system went down. Everyone was scrambling to find a solution, with no luck. After a few hours of troubleshooting, we realized that we needed to call in a professional. We contacted a local plumber, who arrived quickly and was able to diagnose the problem in no time. He was able to repair the faulty wiring and get our instruments and computer system back up and running. We were extremely thankful for his expertise, and all of the researchers were relieved that our experiments could get back on track.\n\nExample complete.\n\nDo not write "You respond with:" in you response\n\nHere are the sentence/sentences that I give you: \n\n\n';
+
   return (
     <>
       <SEO />
       <GridLayout>
         <GridItemSix className={`h-85 scrollbar-hide overflow-y-scroll `}>
-          <DescriptionGPT />
+          <DescriptionGPT showTextArea={true} customPrompt={autocomplete} />
         </GridItemSix>
         <GridItemSix>Test</GridItemSix>
       </GridLayout>

--- a/packages/ui/src/components/DescriptionGPT/DescriptionGPT.stories.tsx
+++ b/packages/ui/src/components/DescriptionGPT/DescriptionGPT.stories.tsx
@@ -12,4 +12,6 @@ const Template: ComponentStory<typeof DescriptionGPT> = (args) => (
 );
 
 export const Default = Template.bind({});
-Default.args = {};
+Default.args = {
+  showTextArea: false,
+};

--- a/packages/ui/src/components/DescriptionGPT/DescriptionGPT.test.tsx
+++ b/packages/ui/src/components/DescriptionGPT/DescriptionGPT.test.tsx
@@ -1,111 +1,108 @@
 import { MockedProvider } from "@apollo/client/testing";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { DescriptionGPT, MESSAGE_TO_GTP } from "./DescriptionGPT";
+import { DescriptionGPT, MESSAGE_TO_GPT } from "./DescriptionGPT";
 
 const mocks = [
   {
     request: {
-      query: MESSAGE_TO_GTP,
+      query: MESSAGE_TO_GPT,
       variables: {
         fields: {
-          message: "This is a test",
+          message: "testing",
+          category: undefined,
         },
       },
     },
     result: {
       data: {
-        messageToGTP: {
-          message: "This is indeed a test",
+        messageToGPT: {
+          message: "example response",
         },
       },
     },
   },
 ];
 
-it("renders without error", async () => {
-  //   const user = userEvent.setup();
+it("component renders and the button is changed to `Autocomplete in progress`, when the button is pressed", async () => {
+  const user = userEvent.setup();
 
   render(
-    <MockedProvider mocks={mocks} addTypename={false}>
-      <DescriptionGPT />
+    <MockedProvider mocks={mocks}>
+      <DescriptionGPT showTextArea={true} customPrompt={""} />
     </MockedProvider>
   );
-  //   await user.click(screen.getByRole("button"));
-  //   await screen.debug();
-
-  //   expect(screen.findByText("Autocomplete in progress"));
-  //   await screen.findByText("This is indeed a test");
+  await waitFor(() => {
+    user.type(screen.getByRole("textbox"), "testing");
+    user.click(screen.getByRole("button"));
+    expect(screen.getByText("Autocomplete in progress")).toBeInTheDocument();
+    screen.debug();
+  });
 });
 
 ////////////////////////////////////////////////////////////////////////////
+
 // describe("DescriptionGPT", () => {
-//   let mockMutation, mockCategory, mockEvent, mockResponse;
-
-//   beforeEach(() => {
-//     mockMutation = jest.fn();
-//     mockCategory = jest.fn();
-//     mockEvent = jest.fn();
-//     mockResponse = jest.fn();
-//   });
-
-//   it("should call mutation when the button is clicked", () => {
-//     const { getByTestId } = render(<DescriptionGPT />);
-//     const button = getByTestId("button");
-
-//     fireEvent.click(button);
-//     expect(mockMutation).toHaveBeenCalled();
-//   });
-
-//   it("should pass the correct category to the mutation when the button is clicked", () => {
-//     const { getByTestId } = render(<DescriptionGPT />);
-//     const button = getByTestId("button");
-
-//     fireEvent.click(button);
-//     expect(mockCategory).toHaveBeenCalledWith(Category.Project);
-//   });
-
-//   it("should set the message in the state when the text area is changed", () => {
-//     const { getByTestId } = render(<DescriptionGPT />);
-//     const textarea = getByTestId("textarea");
-
-//     fireEvent.change(textarea, mockEvent);
-//     expect(mockMutation).toHaveBeenCalledWith(mockEvent.target.value);
-//   });
-
-//   it("should pass the message to the mutation when it is triggered", () => {
-//     const { getByTestId } = render(<DescriptionGPT />);
-//     const textarea = getByTestId("textarea");
-
-//     fireEvent.change(textarea, mockEvent);
-//     fireEvent.click(getByTestId("button"));
-//     expect(MESSAGE_TO_GTP).toHaveBeenCalledWith({
-//       variables: {
-//         fields: {
-//           message: mockEvent.target.value,
-//           category: Category.Project,
+//   const mocks = [
+//     {
+//       request: {
+//         query: MESSAGE_TO_GPT,
+//         variables: {
+//           fields: {
+//             message: "example text",
+//             category: "skill",
+//             prompt: "",
+//           },
 //         },
 //       },
-//       context: { serviceName: "soilservice" },
+//       result: {
+//         data: {
+//           messageToGPT: {
+//             message: "example response",
+//           },
+//         },
+//       },
+//     },
+//   ];
+
+//   it("renders without crashing", async () => {
+//     const { getByTestId } = render(
+//       <MockedProvider mocks={mocks}>
+//         <DescriptionGPT showTextArea={true} />
+//       </MockedProvider>
+//     );
+
+//     await waitFor(() => {
+//       expect(getByTestId("text-area")).toBeInTheDocument();
 //     });
 //   });
 
-//   it("should return the correct message from the mutation", () => {
-//     const { getByTestId } = render(<DescriptionGPT />);
-//     const textarea = getByTestId("textarea");
+//   it("calls the mutation when the button is clicked", async () => {
+//     const { getByTestId } = render(
+//       <MockedProvider mocks={mocks}>
+//         <DescriptionGPT showTextArea={true} />
+//       </MockedProvider>
+//     );
+//     const textArea = getByTestId("text-area");
 
-//     fireEvent.change(textarea, mockEvent);
-//     fireEvent.click(getByTestId("button"));
-//     expect(mockResponse).toHaveBeenCalledWith(messageToGPT.message);
+//     fireEvent.change(textArea, { target: { value: "example text" } });
+//     fireEvent.click(getByTestId("submit-button"));
+//     await waitFor(() => {
+//       expect(getByTestId("response")).toHaveTextContent("example response");
+//     });
 //   });
 
-//   it("should set the message in the state when the mutation is completed", () => {
-//     const { getByTestId } = render(<DescriptionGPT />);
-//     const textarea = getByTestId("textarea");
+//   it("displays a custom prompt if provided", async () => {
+//     const customPrompt = "Please enter a description for your skill:";
+//     const { getByText } = render(
+//       <MockedProvider mocks={mocks}>
+//         <DescriptionGPT showTextArea={true} customPrompt={customPrompt} />
+//       </MockedProvider>
+//     );
 
-//     fireEvent.change(textarea, mockEvent);
-//     fireEvent.click(getByTestId("button"));
-//     expect(setMessage).toHaveBeenCalledWith(messageToGPT.message);
+//     await waitFor(() => {
+//       expect(getByText(customPrompt)).toBeInTheDocument();
+//     });
 //   });
 // });

--- a/packages/ui/src/components/DescriptionGPT/DescriptionGPT.tsx
+++ b/packages/ui/src/components/DescriptionGPT/DescriptionGPT.tsx
@@ -2,7 +2,7 @@ import { gql, useMutation } from "@apollo/client";
 import { Button, TextArea } from "@eden/package-ui";
 import { useState } from "react";
 
-export const MESSAGE_TO_GTP = gql`
+export const MESSAGE_TO_GPT = gql`
   mutation ($fields: messageToGPTInput!) {
     messageToGPT(fields: $fields) {
       message
@@ -16,14 +16,20 @@ enum Category {
   Role = "role",
 }
 
-export interface IDescriptionGPTProps {}
+export interface IDescriptionGPTProps {
+  showTextArea: boolean;
+  customPrompt?: string;
+}
 
-export const DescriptionGPT = ({}: IDescriptionGPTProps) => {
+export const DescriptionGPT = ({
+  showTextArea,
+  customPrompt,
+}: IDescriptionGPTProps) => {
   const [responseFromGTP, setResponseFromGTP] = useState("");
   const [messageToGTP, setMessageToGTP] = useState("");
   const [loadingButton, setLoadingButton] = useState(false);
 
-  const [messageToGPT] = useMutation(MESSAGE_TO_GTP, {
+  const [messageToGPT] = useMutation(MESSAGE_TO_GPT, {
     onCompleted({ messageToGPT }) {
       if (messageToGPT) console.log("messageToGPT", messageToGPT);
       setResponseFromGTP(messageToGPT.message);
@@ -31,22 +37,23 @@ export const DescriptionGPT = ({}: IDescriptionGPTProps) => {
     },
   });
 
-  const autocomplete =
-    "I give you a sentence or two and you keep those sentences unchanged, deduce meaning and continue writing the next few sentences within that same context.\n\nExample: \nI write: A plumber is a tradesperson who specializes in installing and maintaining systems used for water, sewage and drainage. They are responsible for installing, repairing and maintaining pipes, fixtures and other plumbing equipment.\nYou respond with:  A plumber is a tradesperson who specializes in installing and maintaining systems used for water, sewage and drainage. They are responsible for installing, repairing and maintaining pipes, fixtures and other plumbing equipment.   Plumbers also inspect structures to identify any potential problems, such as clogged drains, leaking pipes and faulty water heaters. In addition, they install appliances such as dishwashers and water heaters, and may be asked to perform basic carpentry work to install kitchen and bathroom cabinets.\nI write: Today was a crazy day in the lab, instruments were not working and our computer system went down. Everyone was scrambling to find a solution, with no luck. \nYou respond with: Today was a crazy day in the lab, instruments were not working and our computer system went down. Everyone was scrambling to find a solution, with no luck. After a few hours of troubleshooting, we realized that we needed to call in a professional. We contacted a local plumber, who arrived quickly and was able to diagnose the problem in no time. He was able to repair the faulty wiring and get our instruments and computer system back up and running. We were extremely thankful for his expertise, and all of the researchers were relieved that our experiments could get back on track.\n\nExample complete.";
+  // const autocomplete =
+  //   'I want you to act as a text extension assistant. Do not edit or change the sentences I give you in any way. I give you sentences and you return those sentences unedited with a continuation to those sentences. \nExample: \nI write: A plumber is a tradesperson who specializes in installing and maintaining systems used for water, sewage and drainage. They are responsible for installing, repairing and maintaining pipes, fixtures and other plumbing equipment.\nYou respond with:  A plumber is a tradesperson who specializes in installing and maintaining systems used for water, sewage and drainage. They are responsible for installing, repairing and maintaining pipes, fixtures and other plumbing equipment.   Plumbers also inspect structures to identify any potential problems, such as clogged drains, leaking pipes and faulty water heaters. In addition, they install appliances such as dishwashers and water heaters, and may be asked to perform basic carpentry work to install kitchen and bathroom cabinets.\nI write: Today was a crazy day in the lab, instruments were not working and our computer system went down. Everyone was scrambling to find a solution, with no luck. \nYou respond with: Today was a crazy day in the lab, instruments were not working and our computer system went down. Everyone was scrambling to find a solution, with no luck. After a few hours of troubleshooting, we realized that we needed to call in a professional. We contacted a local plumber, who arrived quickly and was able to diagnose the problem in no time. He was able to repair the faulty wiring and get our instruments and computer system back up and running. We were extremely thankful for his expertise, and all of the researchers were relieved that our experiments could get back on track.\n\nExample complete.\n\nDo not write "You respond with:" in you response\n\nHere are the sentence/sentences that I give you: \n\n\n';
 
   const onClickGPT = (prompt?: any, category?: Category) => {
     setLoadingButton(true);
     messageToGPT({
       variables: {
         fields: {
-          message: autocomplete + messageToGTP,
+          message: customPrompt + messageToGTP,
           category: category,
           prompt: prompt,
         },
       },
       context: { serviceName: "soilservice" },
     });
-    console.log(prompt);
+    // console.log("prompt", prompt);
+    // console.log("customPrompt", customPrompt);
   };
 
   const handleChange = (e: any) => {
@@ -63,13 +70,15 @@ export const DescriptionGPT = ({}: IDescriptionGPTProps) => {
   return (
     <>
       <div className=" items-end space-y-2">
-        <TextArea
-          placeholder="Start writing the name of the project and let the Eden AI autocomplete it or type the full description "
-          label="Project Description  "
-          onChange={handleChange}
-          value={responseFromGTP ? responseFromGTP : messageToGTP}
-          rows={8}
-        />
+        {showTextArea && (
+          <TextArea
+            placeholder="Start writing the name of the project and let the Eden AI autocomplete it or type the full description "
+            label="Project Description"
+            onChange={handleChange}
+            value={responseFromGTP ? responseFromGTP : messageToGTP}
+            rows={8}
+          />
+        )}
         {!loadingButton ? (
           <Button
             variant="primary"


### PR DESCRIPTION
- Now you can pass a prompt to `DescriptionGPT` component anywhere it is used as a child. 
- The text box is now conditionally rendered for testing purposes
      -  By default, textArea will not be rendered and it will just render the `Eden AI Autocomplete` button 
- The autocomplete prompt is improved once again 
- The test for this component is slightly more useful than before