### PR TITLE
update graphql packages

### DIFF
--- a/apps/alpha/package.json
+++ b/apps/alpha/package.json
@@ -11,7 +11,7 @@
     "clean-windows": "rd /s /q node_modules && rd /s /q .next"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "^3.7.5",
     "@eden/package-context": "*",
     "@eden/package-graphql": "*",
     "@eden/package-ui": "*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "clean-windows": "rd /s /q node_modules && rd /s /q .next"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "^3.7.5",
     "@eden/package-context": "*",
     "@eden/package-graphql": "*",
     "@eden/package-ui": "*",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.2.4",
     "jest": "^29.3.1",
-    "jest-environment-jsdom": "^29.3.1"
+    "jest-environment-jsdom": "^29.3.1",
+    "ts-node": "^10.9.1"
   },
   "packageManager": "yarn@1.22.18",
   "lint-staged": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -9,11 +9,11 @@
     "codegen:eden": "graphql-codegen --config eden/codegen.yml"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "^3.7.5",
     "apollo-utilities": "^1.3.4",
     "axios": "^1.2.1",
     "eslint-config-next": "^12.0.3",
-    "graphql-ws": "^5.10.1",
+    "graphql-ws": "^5.11.2",
     "jwt-decode": "^3.1.2"
   },
   "devDependencies": {

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -10,7 +10,7 @@
     "clean-windows": "rd /s /q node_modules"
   },
   "devDependencies": {
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "^3.7.5",
     "@eden/package-config": "*",
     "@eden/package-graphql": "*",
     "@eden/package-tsconfig": "*",

--- a/packages/ui/src/components/DescriptionGPT/DescriptionGPT.test.tsx
+++ b/packages/ui/src/components/DescriptionGPT/DescriptionGPT.test.tsx
@@ -37,7 +37,7 @@ it("component renders and the button is changed to `Autocomplete in progress`, w
     user.type(screen.getByRole("textbox"), "testing");
     user.click(screen.getByRole("button"));
     expect(screen.getByText("Autocomplete in progress")).toBeInTheDocument();
-    screen.debug();
+    // screen.debug();
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,10 +266,10 @@
     csstype "^3.0.8"
     tslib "^2.0.3"
 
-"@apollo/client@^3.6.9":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.1.tgz#86ce47c18a0714e229231148b0306562550c2248"
-  integrity sha512-xu5M/l7p9gT9Fx7nF3AQivp0XukjB7TM7tOd5wifIpI8RskYveL4I+rpTijzWrnqCPZabkbzJKH7WEAKdctt9w==
+"@apollo/client@^3.7.5":
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.5.tgz#d2ab6e284822296c9102ff57ab3a8dcbaa818052"
+  integrity sha512-HEAhX2n2Y8Y2BwRr0UdteT94OTM7pn64K5/rTk/oLIdg/h7R2d83LdsCGDxSH5sBiqDqlv9vou4xdyTxxRWj/g==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     "@wry/context" "^0.7.0"
@@ -8629,7 +8629,7 @@ graphql-tag@^2.11.0, graphql-tag@^2.12.6:
   dependencies:
     tslib "^2.1.0"
 
-graphql-ws@5.11.2, graphql-ws@^5.10.1:
+graphql-ws@5.11.2, graphql-ws@^5.11.2:
   version "5.11.2"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.11.2.tgz#d5e0acae8b4d4a4cf7be410a24135cfcefd7ddc0"
   integrity sha512-4EiZ3/UXYcjm+xFGP544/yW1+DVI8ZpKASFbzrV5EDTFWJp0ZvLl4Dy2fSZAzz9imKp5pZMIcjB0x/H69Pv/6w==
@@ -14414,7 +14414,7 @@ ts-log@^2.2.3:
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.5.tgz#aef3252f1143d11047e2cb6f7cfaac7408d96623"
   integrity sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==
 
-ts-node@^10.8.1:
+ts-node@^10.8.1, ts-node@^10.9.1:
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
   integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==


### PR DESCRIPTION
this PR updates graphql packages

also adds `ts-node` package to the root, hoping to solve future errors with jest and running `yarn test` after updating more packages 

`Error: Jest: 'ts-node' is required for the TypeScript configuration files. Make sure it is installed`