### PR TITLE
remove apollo client context

### DIFF
--- a/apps/alpha/pages/admin/grants/index.tsx
+++ b/apps/alpha/pages/admin/grants/index.tsx
@@ -76,7 +76,6 @@ const GrantsAdminPage: NextPageWithLayout = () => {
           serverID: data.server._id,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/apps/alpha/pages/admin/party-rooms/index.tsx
+++ b/apps/alpha/pages/admin/party-rooms/index.tsx
@@ -55,7 +55,6 @@ const DiscoverPage: NextPageWithLayout = () => {
     variables: {
       fields: {},
     },
-    context: { serviceName: "soilservice" },
   });
 
   if (dataRoom) console.log("dataRoom", dataRoom);
@@ -82,7 +81,6 @@ const DiscoverPage: NextPageWithLayout = () => {
           serverID: selectedServer?._id,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/apps/alpha/pages/champion-board/recruit/[_id].tsx
+++ b/apps/alpha/pages/champion-board/recruit/[_id].tsx
@@ -42,7 +42,6 @@ const ProjectPage: NextPageWithLayout = () => {
         },
       },
       skip: !_id,
-      context: { serviceName: "soilservice" },
     }
   );
 
@@ -65,7 +64,6 @@ const ProjectPage: NextPageWithLayout = () => {
       !selectedRole ||
       !dataProject?.findProject?.serverID ||
       selectedServerID.length === 0,
-    context: { serviceName: "soilservice" },
   });
 
   // if (matchingMembers) console.log("matchingMembers", matchingMembers);

--- a/apps/alpha/pages/discover/index.tsx
+++ b/apps/alpha/pages/discover/index.tsx
@@ -81,7 +81,6 @@ const DiscoverPage: NextPageWithLayout = () => {
       },
     },
     skip: !nodesID || !selectedServerID,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataMembers) console.log("dataMembers", dataMembers);
@@ -93,7 +92,6 @@ const DiscoverPage: NextPageWithLayout = () => {
       },
     },
     skip: !router.query.project,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataProject) console.log("dataProject", dataProject);

--- a/apps/alpha/pages/grants/index.tsx
+++ b/apps/alpha/pages/grants/index.tsx
@@ -62,7 +62,6 @@ const GrantsPage: NextPageWithLayout = () => {
         // serverID: selectedServerID,
       },
     },
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataGrants) console.log("dataGrants", dataGrants);
@@ -103,7 +102,6 @@ const GrantsPage: NextPageWithLayout = () => {
           nodesID: val,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/apps/alpha/pages/party/host/[partyId].tsx
+++ b/apps/alpha/pages/party/host/[partyId].tsx
@@ -45,7 +45,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataRoom?.findRoom) console.log("dataRoom", dataRoom?.findRoom);
@@ -60,7 +59,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
         },
       },
       skip: !nodesID || !dataRoom?.findRoom?.serverID,
-      context: { serviceName: "soilservice" },
     }
   );
 
@@ -73,7 +71,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       },
     },
     skip: !memberID,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataMember) console.log("dataMember", dataMember?.findMember);
@@ -83,7 +80,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       fields: { _id: partyId },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
   });
 
   const membersIds: Array<string> = dataRoomSubscription
@@ -97,7 +93,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       fields: { _id: partyId },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
     onData: ({ data }) => {
       const newMemberData = data?.data?.memberUpdatedInRoom;
 
@@ -135,7 +130,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
           memberID: currentUser?._id,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   }, [currentUser, membersIds, partyId, dataRoom]);
 
@@ -167,7 +161,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       },
     },
     skip: !membersIds || members.length === membersIds.length,
-    context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       if (data) {
         setMembers(data.findMembers);

--- a/apps/alpha/pages/party/onboard/[partyId].tsx
+++ b/apps/alpha/pages/party/onboard/[partyId].tsx
@@ -59,7 +59,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
         },
       },
       skip: !nodesID || !room?.serverID || error?.length > 0,
-      context: { serviceName: "soilservice" },
     }
   );
 
@@ -78,7 +77,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
       fields: { _id: partyId },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
   });
 
   const membersIds: Array<string> = dataRoomSubscription
@@ -93,7 +91,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
       fields: { _id: partyId },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
     onData: ({ data }) => {
       const newMemberData = data?.data?.memberUpdatedInRoom;
 
@@ -132,7 +129,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
             memberID: currentUser?._id,
           },
         },
-        context: { serviceName: "soilservice" },
       });
       setMemberEnterRoom(true);
     }
@@ -145,7 +141,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
       },
     },
     skip: !membersIds || members.length === membersIds.length,
-    context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       if (data) {
         setMembers(data.findMembers);

--- a/apps/alpha/pages/projects/index.tsx
+++ b/apps/alpha/pages/projects/index.tsx
@@ -69,7 +69,6 @@ const ProjectsPage: NextPageWithLayout = () => {
         },
       },
       skip: !nodesID || !selectedServerID,
-      context: { serviceName: "soilservice" },
     }
   );
 
@@ -122,7 +121,6 @@ const ProjectsPage: NextPageWithLayout = () => {
           nodesID: val,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/apps/alpha/pages/test/chatEden/fake.tsx
+++ b/apps/alpha/pages/test/chatEden/fake.tsx
@@ -93,7 +93,6 @@ const chatEden: NextPageWithLayout = () => {
       },
     },
     skip: messageUser == "",
-    context: { serviceName: "soilservice" },
   });
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/apps/alpha/pages/test/chatEden/index.tsx
+++ b/apps/alpha/pages/test/chatEden/index.tsx
@@ -176,7 +176,6 @@ const chatEden: NextPageWithLayout = () => {
       },
     },
     skip: keywordsDiscussion.length == 0,
-    context: { serviceName: "soilservice" },
   });
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -219,7 +218,6 @@ const chatEden: NextPageWithLayout = () => {
       },
     },
     skip: messageUser == "" || selectedOption != "option1",
-    context: { serviceName: "soilservice" },
   });
 
   const { data: dataEdenGPTReplyMemory } = useQuery(EDEN_GPT_REPLY_MEMORY, {
@@ -231,7 +229,6 @@ const chatEden: NextPageWithLayout = () => {
       },
     },
     skip: messageUser == "" || selectedOption != "option2",
-    context: { serviceName: "soilservice" },
   });
 
   const { data: dataEdenGPTReplyChatAPI } = useQuery(EDEN_GPT_REPLY_CHAT_API, {
@@ -251,7 +248,6 @@ const chatEden: NextPageWithLayout = () => {
       },
     },
     skip: messageUser == "" || selectedOption != "option3",
-    context: { serviceName: "soilservice" },
   });
 
   const { data: dataMessageMapKG } = useQuery(MESSAGE_MAP_KG, {
@@ -261,7 +257,6 @@ const chatEden: NextPageWithLayout = () => {
       },
     },
     skip: messageUser == "",
-    context: { serviceName: "soilservice" },
   });
 
   // console.log("dataMessageMapKG = ", dataMessageMapKG);
@@ -278,7 +273,6 @@ const chatEden: NextPageWithLayout = () => {
       },
     },
     // skip: !nodesID || !selectedServerID,
-    context: { serviceName: "soilservice" },
   });
 
   // console.log("dataMembers = ", dataMembers);
@@ -979,7 +973,6 @@ const UserMessageModal = ({
       },
     },
     skip: messageUser == "",
-    context: { serviceName: "soilservice" },
   });
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/apps/alpha/pages/test/discover/index.tsx
+++ b/apps/alpha/pages/test/discover/index.tsx
@@ -81,7 +81,6 @@ const DiscoverPage: NextPageWithLayout = () => {
       },
     },
     skip: !nodesID || !selectedServerID,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataMembers) console.log("dataMembers", dataMembers);
@@ -93,7 +92,6 @@ const DiscoverPage: NextPageWithLayout = () => {
       },
     },
     skip: !router.query.project,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataProject) console.log("dataProject", dataProject);

--- a/apps/alpha/pages/test/discover_test/index.tsx
+++ b/apps/alpha/pages/test/discover_test/index.tsx
@@ -37,7 +37,6 @@ const DiscoverPage: NextPageWithLayout = () => {
       },
     },
     skip: !nodesID || !selectedServerID,
-    context: { serviceName: "soilservice" },
   });
 
   const { data: dataProject } = useQuery(FIND_PROJECT, {
@@ -47,7 +46,6 @@ const DiscoverPage: NextPageWithLayout = () => {
       },
     },
     skip: !router.query.project,
-    context: { serviceName: "soilservice" },
   });
 
   return (

--- a/apps/alpha/pages/test/discover_with_chat/index.tsx
+++ b/apps/alpha/pages/test/discover_with_chat/index.tsx
@@ -96,7 +96,6 @@ const DiscoverWithChatPage: NextPageWithLayout = () => {
       },
     },
     skip: !nodesID || !selectedServerID,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataMembers) console.log("dataMembers", dataMembers);
@@ -108,7 +107,6 @@ const DiscoverWithChatPage: NextPageWithLayout = () => {
       },
     },
     skip: !router.query.project,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataProject) console.log("dataProject", dataProject);
@@ -557,7 +555,6 @@ const UserMessageModal = ({
       },
     },
     skip: messageUser == "",
-    context: { serviceName: "soilservice" },
   });
 
   // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/apps/alpha/pages/test/g6/MemberToProjectGraph.tsx
+++ b/apps/alpha/pages/test/g6/MemberToProjectGraph.tsx
@@ -126,7 +126,6 @@ const MemberToProjectGraph = (props: any) => {
       },
     },
     skip: props.selectedOption !== "Option 3",
-    context: { serviceName: "soilservice" },
   });
 
   console.log("dataGraphAPImember = ", dataGraphAPImember);

--- a/apps/alpha/pages/test/g6/exampleGraphVisual.tsx
+++ b/apps/alpha/pages/test/g6/exampleGraphVisual.tsx
@@ -622,7 +622,6 @@ const GraphVisualPage: NextPageWithLayout = () => {
       },
     },
     skip: selectedOption !== "Option 3",
-    context: { serviceName: "soilservice" },
   });
 
   const { data: dataGraphAPImemberProject } = useQuery(
@@ -690,7 +689,6 @@ const GraphVisualPage: NextPageWithLayout = () => {
         },
       },
       skip: selectedOption !== "Option 2",
-      context: { serviceName: "soilservice" },
     }
   );
 
@@ -769,7 +767,6 @@ const GraphVisualPage: NextPageWithLayout = () => {
       },
     },
     skip: selectedOption !== "Option 6",
-    context: { serviceName: "soilservice" },
   });
 
   const { data: dataDynamicSearch, refetch: refetchDynamicSearch } = useQuery(
@@ -835,7 +832,6 @@ const GraphVisualPage: NextPageWithLayout = () => {
         },
       },
       skip: selectedOption !== "Option 8",
-      context: { serviceName: "soilservice" },
     }
   );
 
@@ -929,7 +925,6 @@ const GraphVisualPage: NextPageWithLayout = () => {
       },
     },
     skip: selectedOption !== "Option 7",
-    context: { serviceName: "soilservice" },
   });
 
   const { data: dataGraphAPIProject } = useQuery(FIND_PROJECT_GRAPH, {
@@ -1012,7 +1007,6 @@ const GraphVisualPage: NextPageWithLayout = () => {
       },
     },
     skip: selectedOption !== "Option 4",
-    context: { serviceName: "soilservice" },
   });
 
   const { data: dataGraphAPIMultipleMembersProjects } = useQuery(
@@ -1127,7 +1121,6 @@ const GraphVisualPage: NextPageWithLayout = () => {
         },
       },
       skip: selectedOption !== "Option 5",
-      context: { serviceName: "soilservice" },
     }
   );
 

--- a/apps/web/pages/admin/error-log/index.tsx
+++ b/apps/web/pages/admin/error-log/index.tsx
@@ -53,7 +53,6 @@ const ErrorLogPage: NextPageWithLayout = () => {
         errorType: typeSelected,
       },
     },
-    context: { serviceName: "soilservice" },
   });
 
   const { errorsData, pageInfo } = dataErrors?.errors || {};
@@ -76,7 +75,6 @@ const ErrorLogPage: NextPageWithLayout = () => {
           _id: _id,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/apps/web/pages/admin/party-rooms/index.tsx
+++ b/apps/web/pages/admin/party-rooms/index.tsx
@@ -55,7 +55,6 @@ const DiscoverPage: NextPageWithLayout = () => {
     variables: {
       fields: {},
     },
-    context: { serviceName: "soilservice" },
   });
 
   // console.log("dataRoom", dataRoom);
@@ -82,7 +81,6 @@ const DiscoverPage: NextPageWithLayout = () => {
           serverID: selectedServer?._id,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/apps/web/pages/champion-board/recruit/[_id].tsx
+++ b/apps/web/pages/champion-board/recruit/[_id].tsx
@@ -40,7 +40,6 @@ const ProjectPage: NextPageWithLayout = () => {
       },
     },
     skip: !_id,
-    context: { serviceName: "soilservice" },
   });
 
   const [selectedRole, setSelectedRole] = useState(
@@ -62,7 +61,6 @@ const ProjectPage: NextPageWithLayout = () => {
       !selectedRole ||
       !dataProject?.findProject?.serverID ||
       selectedServerID.length === 0,
-    context: { serviceName: "soilservice" },
   });
 
   // if (matchingMembers) console.log("matchingMembers", matchingMembers);

--- a/apps/web/pages/discover/index.tsx
+++ b/apps/web/pages/discover/index.tsx
@@ -49,7 +49,6 @@ const DiscoverPage: NextPageWithLayout = () => {
       },
     },
     skip: !nodesID || !selectedServerID,
-    context: { serviceName: "soilservice" },
   });
 
   const { data: dataProject } = useQuery(FIND_PROJECT, {
@@ -59,7 +58,6 @@ const DiscoverPage: NextPageWithLayout = () => {
       },
     },
     skip: !router.query.project,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataMembers) console.log("dataMembers", dataMembers);

--- a/apps/web/pages/grants/index.tsx
+++ b/apps/web/pages/grants/index.tsx
@@ -62,7 +62,6 @@ const GrantsPage: NextPageWithLayout = () => {
         // serverID: selectedServerID,
       },
     },
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataGrants) console.log("dataGrants", dataGrants);
@@ -103,7 +102,6 @@ const GrantsPage: NextPageWithLayout = () => {
           nodesID: val,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/apps/web/pages/party/host/[partyId].tsx
+++ b/apps/web/pages/party/host/[partyId].tsx
@@ -45,7 +45,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataRoom?.findRoom) console.log("dataRoom", dataRoom?.findRoom);
@@ -60,7 +59,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
         },
       },
       skip: !nodesID || !dataRoom?.findRoom?.serverID,
-      context: { serviceName: "soilservice" },
     }
   );
 
@@ -73,7 +71,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       },
     },
     skip: !memberID,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataMember) console.log("dataMember", dataMember?.findMember);
@@ -83,7 +80,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       fields: { _id: partyId },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
   });
 
   const membersIds: Array<string> = dataRoomSubscription
@@ -97,7 +93,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       fields: { _id: partyId },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
     onData: ({ data }) => {
       const newMemberData = data?.data?.memberUpdatedInRoom;
 
@@ -135,7 +130,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
           memberID: currentUser?._id,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   }, [currentUser, membersIds, partyId, dataRoom]);
 
@@ -167,7 +161,6 @@ const OnboardPartyPage: NextPageWithLayout = () => {
       },
     },
     skip: !membersIds || members.length === membersIds.length,
-    context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       if (data) {
         setMembers(data.findMembers);

--- a/apps/web/pages/party/onboard/[partyId].tsx
+++ b/apps/web/pages/party/onboard/[partyId].tsx
@@ -59,7 +59,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
         },
       },
       skip: !nodesID || !room?.serverID || error?.length > 0,
-      context: { serviceName: "soilservice" },
     }
   );
 
@@ -78,7 +77,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
       fields: { _id: partyId },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
   });
 
   const membersIds: Array<string> = dataRoomSubscription
@@ -93,7 +91,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
       fields: { _id: partyId },
     },
     skip: !partyId,
-    context: { serviceName: "soilservice" },
     onData: ({ data }) => {
       const newMemberData = data?.data?.memberUpdatedInRoom;
 
@@ -132,7 +129,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
             memberID: currentUser?._id,
           },
         },
-        context: { serviceName: "soilservice" },
       });
       setMemberEnterRoom(true);
     }
@@ -145,7 +141,6 @@ const OnboardPartyPage: NextPageWithLayout = ({
       },
     },
     skip: !membersIds || members.length === membersIds.length,
-    context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       if (data) {
         setMembers(data.findMembers);

--- a/apps/web/pages/projects/index.tsx
+++ b/apps/web/pages/projects/index.tsx
@@ -68,7 +68,6 @@ const ProjectsPage: NextPageWithLayout = () => {
         },
       },
       skip: !nodesID || !selectedServerID,
-      context: { serviceName: "soilservice" },
     }
   );
 
@@ -121,7 +120,6 @@ const ProjectsPage: NextPageWithLayout = () => {
           nodesID: val,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/packages/graphql/generated/graphqlEden.ts
+++ b/packages/graphql/generated/graphqlEden.ts
@@ -258,6 +258,7 @@ export type Mutation = {
   relatedNode_name?: Maybe<Node>;
   saveCoreProductFeatureInteration?: Maybe<Scalars["Boolean"]>;
   saveDailyLogin?: Maybe<Scalars["Boolean"]>;
+  storeLongTermMemory?: Maybe<StoreLongTermMemoryOutput>;
   updateChatReply?: Maybe<Chats>;
   updateChatResult?: Maybe<Chats>;
   updateGrant?: Maybe<GrantTemplate>;
@@ -434,6 +435,10 @@ export type MutationSaveDailyLoginArgs = {
   fields?: InputMaybe<SaveDailyLoginInput>;
 };
 
+export type MutationStoreLongTermMemoryArgs = {
+  fields?: InputMaybe<StoreLongTermMemoryInput>;
+};
+
 export type MutationUpdateChatReplyArgs = {
   fields?: InputMaybe<UpdateChatReplyInput>;
 };
@@ -608,6 +613,8 @@ export type Query = {
   dynamicSearchToMemberGraph?: Maybe<Graph>;
   dynamicSearchToProjectGraph?: Maybe<Graph>;
   edenGPTreply?: Maybe<EdenGpTreplyOutput>;
+  edenGPTreplyChatAPI?: Maybe<EdenGpTreplyChatApiOutput>;
+  edenGPTreplyMemory?: Maybe<EdenGpTreplyMemoryOutput>;
   edenGPTsearchProfiles?: Maybe<EdenGpTsearchProfilesOutput>;
   errors?: Maybe<PaginatedErrorLogs>;
   findAllProjectsTeamsAnouncments?: Maybe<
@@ -669,6 +676,7 @@ export type Query = {
   match_projectToUser?: Maybe<ProjectUserMatchType>;
   membersStats?: Maybe<Array<Maybe<ResultCount>>>;
   members_autocomplete?: Maybe<Array<Maybe<Members>>>;
+  messageMapKG?: Maybe<MessageMapKgOutput>;
   nodes_autocomplete?: Maybe<Array<Maybe<Node>>>;
   setAllMatch_v2?: Maybe<Scalars["Boolean"]>;
   skills?: Maybe<PaginatedSkills>;
@@ -699,6 +707,14 @@ export type QueryDynamicSearchToProjectGraphArgs = {
 
 export type QueryEdenGpTreplyArgs = {
   fields?: InputMaybe<EdenGpTreplyInput>;
+};
+
+export type QueryEdenGpTreplyChatApiArgs = {
+  fields?: InputMaybe<EdenGpTreplyChatApiInput>;
+};
+
+export type QueryEdenGpTreplyMemoryArgs = {
+  fields?: InputMaybe<EdenGpTreplyMemoryInput>;
 };
 
 export type QueryEdenGpTsearchProfilesArgs = {
@@ -915,6 +931,10 @@ export type QueryMembersStatsArgs = {
 
 export type QueryMembers_AutocompleteArgs = {
   fields?: InputMaybe<Members_AutocompleteInput>;
+};
+
+export type QueryMessageMapKgArgs = {
+  fields?: InputMaybe<MessageMapKgInput>;
 };
 
 export type QueryNodes_AutocompleteArgs = {
@@ -1523,13 +1543,34 @@ export type DynamicSearchToProjectGraphInput = {
   showAvatar?: InputMaybe<Scalars["Boolean"]>;
 };
 
+export type EdenGpTreplyChatApiInput = {
+  conversation?: InputMaybe<Array<InputMaybe<MessageChat>>>;
+  message?: InputMaybe<Scalars["String"]>;
+  userID?: InputMaybe<Scalars["ID"]>;
+};
+
+export type EdenGpTreplyChatApiOutput = {
+  __typename?: "edenGPTreplyChatAPIOutput";
+  reply?: Maybe<Scalars["String"]>;
+};
+
 export type EdenGpTreplyInput = {
   message?: InputMaybe<Scalars["String"]>;
 };
 
+export type EdenGpTreplyMemoryInput = {
+  memorySort?: InputMaybe<Scalars["String"]>;
+  message?: InputMaybe<Scalars["String"]>;
+  userID?: InputMaybe<Scalars["ID"]>;
+};
+
+export type EdenGpTreplyMemoryOutput = {
+  __typename?: "edenGPTreplyMemoryOutput";
+  reply?: Maybe<Scalars["String"]>;
+};
+
 export type EdenGpTreplyOutput = {
   __typename?: "edenGPTreplyOutput";
-  keywords?: Maybe<Array<Maybe<Scalars["String"]>>>;
   reply?: Maybe<Scalars["String"]>;
 };
 
@@ -1855,6 +1896,13 @@ export type InputToGptOutput = {
   expectationsRole?: Maybe<Array<Maybe<Scalars["String"]>>>;
 };
 
+export type KeywordValue = {
+  __typename?: "keywordValue";
+  confidence?: Maybe<Scalars["Int"]>;
+  keyword?: Maybe<Scalars["String"]>;
+  nodeID?: Maybe<Scalars["ID"]>;
+};
+
 export enum LevelEnum {
   Junior = "junior",
   Learning = "learning",
@@ -2035,6 +2083,26 @@ export type Match_V2_UpdateType = {
 
 export type Members_AutocompleteInput = {
   search?: InputMaybe<Scalars["String"]>;
+};
+
+export type MessageChat = {
+  content?: InputMaybe<Scalars["String"]>;
+  role?: InputMaybe<Scalars["String"]>;
+};
+
+export type MessageInp = {
+  date?: InputMaybe<Scalars["String"]>;
+  message?: InputMaybe<Scalars["String"]>;
+  name?: InputMaybe<Scalars["String"]>;
+};
+
+export type MessageMapKgInput = {
+  message?: InputMaybe<Scalars["String"]>;
+};
+
+export type MessageMapKgOutput = {
+  __typename?: "messageMapKGOutput";
+  keywords?: Maybe<Array<Maybe<KeywordValue>>>;
 };
 
 export type MessageToGptInput = {
@@ -2385,6 +2453,17 @@ export type StatsInput = {
   endDate?: InputMaybe<Scalars["Date"]>;
   range?: InputMaybe<Range>;
   startDate?: InputMaybe<Scalars["Date"]>;
+};
+
+export type StoreLongTermMemoryInput = {
+  messages?: InputMaybe<Array<InputMaybe<MessageInp>>>;
+  userID?: InputMaybe<Scalars["ID"]>;
+};
+
+export type StoreLongTermMemoryOutput = {
+  __typename?: "storeLongTermMemoryOutput";
+  success?: Maybe<Scalars["Boolean"]>;
+  summary?: Maybe<Scalars["String"]>;
 };
 
 export type StyleEdgeIn = {

--- a/packages/ui/src/archive/cards/project/ProjectRecommendedCard/ProjectRecommendedCard.tsx
+++ b/packages/ui/src/archive/cards/project/ProjectRecommendedCard/ProjectRecommendedCard.tsx
@@ -60,7 +60,6 @@ export const ProjectRecommendedCard = ({
           favorite: !fav,
         },
       },
-      context: { serviceName: "soilservice" },
     });
     updateFav(!fav);
   };

--- a/packages/ui/src/archive/containers/ApplyByRoleContainer/ApplyByRoleContainer.tsx
+++ b/packages/ui/src/archive/containers/ApplyByRoleContainer/ApplyByRoleContainer.tsx
@@ -141,7 +141,6 @@ export const ApplyByRoleContainer = ({
                     favorite: !isFavorite,
                   },
                 },
-                context: { serviceName: "soilservice" },
               });
             }}
           />

--- a/packages/ui/src/archive/containers/SignUpContainer/SignUpContainer.tsx
+++ b/packages/ui/src/archive/containers/SignUpContainer/SignUpContainer.tsx
@@ -88,7 +88,6 @@ export const SignUpContainer = ({}: SignUpContainerProps) => {
           },
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/packages/ui/src/archive/layout/AppUserMenuLayout/AppUserMenuLayout.tsx
+++ b/packages/ui/src/archive/layout/AppUserMenuLayout/AppUserMenuLayout.tsx
@@ -41,7 +41,6 @@ export const AppUserMenuLayout = ({
         },
       },
       skip: !currentUser,
-      context: { serviceName: "soilservice" },
     }
   );
 

--- a/packages/ui/src/archive/modals/ApplyByRoleModal/ApplyByRoleModal.tsx
+++ b/packages/ui/src/archive/modals/ApplyByRoleModal/ApplyByRoleModal.tsx
@@ -129,7 +129,6 @@ export const ApplyByRoleModal = ({
           ],
         },
       },
-      context: { serviceName: "soilservice" },
     });
     changeTeamMemberPhaseProject({
       variables: {
@@ -140,7 +139,6 @@ export const ApplyByRoleModal = ({
           phase: "engaged",
         },
       },
-      context: { serviceName: "soilservice" },
     });
 
     setApplied(true);

--- a/packages/ui/src/archive/modals/EditProjectModal/EditProjectModal.tsx
+++ b/packages/ui/src/archive/modals/EditProjectModal/EditProjectModal.tsx
@@ -104,7 +104,6 @@ export const EditProjectModal = ({
           ],
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/packages/ui/src/archive/modals/RoleModal/RoleModal.tsx
+++ b/packages/ui/src/archive/modals/RoleModal/RoleModal.tsx
@@ -28,7 +28,6 @@ export const RoleModal = ({
     variables: {
       fields: {},
     },
-    context: { serviceName: "soilservice" },
   });
 
   const onSelect = (val: Maybe<RoleTemplate>) => {

--- a/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.tsx
+++ b/packages/ui/src/cards/EditProfileOnboardPartyNodesCard/EditProfileOnboardPartyNodesCard.tsx
@@ -70,7 +70,6 @@ export const EditProfileOnboardPartyNodesCard = ({
         _id: null,
       },
     },
-    context: { serviceName: "soilservice" },
   });
 
   const progress = getFillProfilePercentage(currentUser || {});
@@ -119,7 +118,6 @@ export const EditProfileOnboardPartyNodesCard = ({
           links: links,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 
@@ -136,7 +134,6 @@ export const EditProfileOnboardPartyNodesCard = ({
           nodesID: filteredNodes,
         },
       },
-      context: { serviceName: "soilservice" },
     });
   };
 

--- a/packages/ui/src/components/ClassicGraphs/DynamicSearchGraph/DynamicSearchGraph.tsx
+++ b/packages/ui/src/components/ClassicGraphs/DynamicSearchGraph/DynamicSearchGraph.tsx
@@ -142,7 +142,6 @@ export const DynamicSearchGraph = ({
     },
     skip: nodesID == undefined,
     // skip: selectedOption !== "Option 8",
-    context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       if (data) {
         setDataGraphAPI(data.dynamicSearchGraph);

--- a/packages/ui/src/components/ClassicGraphs/DynamicSearchMemberGraph/DynamicSearchMemberGraph.tsx
+++ b/packages/ui/src/components/ClassicGraphs/DynamicSearchMemberGraph/DynamicSearchMemberGraph.tsx
@@ -125,7 +125,6 @@ export const DynamicSearchMemberGraph = ({
     },
     skip: nodesID == undefined,
     // skip: selectedOption !== "Option 8",
-    context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       if (data) {
         setDataGraphAPI(data.dynamicSearchToMemberGraph);

--- a/packages/ui/src/components/ClassicGraphs/MemberGraph/MemberGraph.tsx
+++ b/packages/ui/src/components/ClassicGraphs/MemberGraph/MemberGraph.tsx
@@ -110,7 +110,6 @@ export const MemberGraph = ({ memberId, disableZoom }: IMemberGraphProps) => {
       },
     },
     skip: !memberId,
-    context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       if (data) {
         setDataGraphAPI(data.findMemberGraph);

--- a/packages/ui/src/components/ClassicGraphs/MemberProjectGraph/MemberProjectGraph.tsx
+++ b/packages/ui/src/components/ClassicGraphs/MemberProjectGraph/MemberProjectGraph.tsx
@@ -120,7 +120,6 @@ export const MemberProjectGraph = ({
       },
     },
     skip: !memberId,
-    context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       if (data) {
         setDataGraphAPI(data.findMemberToProjectGraph);

--- a/packages/ui/src/components/ClassicGraphs/ProjectGraph/ProjectGraph.tsx
+++ b/packages/ui/src/components/ClassicGraphs/ProjectGraph/ProjectGraph.tsx
@@ -141,7 +141,6 @@ export const ProjectGraph = ({ projectId }: IProjectGraphProps) => {
       },
     },
     skip: !projectId,
-    context: { serviceName: "soilservice" },
     onCompleted: (data) => {
       if (data) {
         setDataGraphAPI(data.findProjectGraph);

--- a/packages/ui/src/components/DescriptionGPT/DescriptionGPT.tsx
+++ b/packages/ui/src/components/DescriptionGPT/DescriptionGPT.tsx
@@ -102,7 +102,6 @@ export const DescriptionGPT = ({
             prompt: prompt,
           },
         },
-        context: { serviceName: "soilservice" },
       });
     }
     if (onClickGPTCondition === "inputToGPT") {
@@ -116,7 +115,6 @@ export const DescriptionGPT = ({
             expertiseRole: expertiseRole,
           },
         },
-        context: { serviceName: "soilservice" },
       });
       // console.log("inputToGPT", inputToGPT);
       // console.log(

--- a/packages/ui/src/components/DiscoverTalent/DiscoverTalent.tsx
+++ b/packages/ui/src/components/DiscoverTalent/DiscoverTalent.tsx
@@ -72,7 +72,6 @@ export const DiscoverTalent = ({
       },
     },
     skip: !nodeType,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataNodes?.findNodes) console.log("dataNodes", dataNodes?.findNodes);

--- a/packages/ui/src/containers/AdminReportsContainer/AdminReportsContainer.tsx
+++ b/packages/ui/src/containers/AdminReportsContainer/AdminReportsContainer.tsx
@@ -458,7 +458,6 @@ export const BarsNewMembers = ({ range, startDate, endDate }: any) => {
       },
     },
     skip: !range || !startDate || !endDate,
-    context: { serviceName: "soilservice" },
   });
 
   const formatData = () => {

--- a/packages/ui/src/containers/CreateProjectContainer/CreateProjectContainer.tsx
+++ b/packages/ui/src/containers/CreateProjectContainer/CreateProjectContainer.tsx
@@ -107,7 +107,6 @@ export const CreateProjectContainer = ({
               nodeType: `sub_expertise`,
             },
           },
-          context: { serviceName: "soilservice" },
         });
 
         if (createProject?.role && i >= createProject?.role?.length - 1) {
@@ -141,7 +140,6 @@ export const CreateProjectContainer = ({
               nodeType: `sub_expertise`,
             },
           },
-          context: { serviceName: "soilservice" },
         });
 
         if (updateProject?.role && i >= updateProject?.role?.length - 1) {
@@ -185,7 +183,6 @@ export const CreateProjectContainer = ({
             serverID: state?.serverID,
           },
         },
-        context: { serviceName: "soilservice" },
       });
     } else {
       createProject({
@@ -209,7 +206,6 @@ export const CreateProjectContainer = ({
             serverID: state?.serverID,
           },
         },
-        context: { serviceName: "soilservice" },
       });
     }
   };

--- a/packages/ui/src/elements/SelectNodes/SelectNodes.tsx
+++ b/packages/ui/src/elements/SelectNodes/SelectNodes.tsx
@@ -35,7 +35,6 @@ export const SelectNodes = ({
         node: nodeType,
       },
     },
-    context: { serviceName: "soilservice" },
     skip: !nodeType,
   });
 

--- a/packages/ui/src/modals/MemberModal/MemberModal.tsx
+++ b/packages/ui/src/modals/MemberModal/MemberModal.tsx
@@ -23,7 +23,6 @@ export const MemberModal = ({
       },
     },
     skip: !member?._id || !open,
-    context: { serviceName: "soilservice" },
   });
 
   const findMember = dataMemberInfo?.findMember;

--- a/packages/ui/src/modals/SelectNodesModal/SelectNodesModal.tsx
+++ b/packages/ui/src/modals/SelectNodesModal/SelectNodesModal.tsx
@@ -46,7 +46,6 @@ export const SelectNodesModal = ({
       },
     },
     skip: !nodeType,
-    context: { serviceName: "soilservice" },
   });
 
   if (dataNodes?.findNodes) console.log("dataNodes", dataNodes?.findNodes);

--- a/packages/ui/src/modals/TestDiscoverTalentDropdownModal/TestDiscoverTalentDropdownModal.tsx
+++ b/packages/ui/src/modals/TestDiscoverTalentDropdownModal/TestDiscoverTalentDropdownModal.tsx
@@ -3,7 +3,7 @@ import { Node } from "@eden/package-graphql/generated";
 import {
   Button,
   Loading,
-  Modal,
+  // Modal,
   SelectBoxNode,
   TextBody,
   TextHeading3,
@@ -49,12 +49,12 @@ export interface ITestDiscoverTalentDropdownModalProps {
 export const TestDiscoverTalentDropdownModal = ({
   openModal,
   onNext,
-  onPrev,
+  // onPrev,
   title = `Your role`,
   subTitle = ``,
   nodeType,
-  batteryPercentage,
-}: ITestDiscoverTalentDropdownModalProps) => {
+}: // batteryPercentage,
+ITestDiscoverTalentDropdownModalProps) => {
   // console.log("hackathon talent dropdown modal", dataNodes);
   const section: Data = useMemo(
     () => ({
@@ -81,7 +81,6 @@ export const TestDiscoverTalentDropdownModal = ({
       },
     },
     skip: !nodeType,
-    context: { serviceName: "soilservice" },
   });
 
   // if (dataNodes?.findNodes) console.log("dataNodes", dataNodes?.findNodes);
@@ -94,9 +93,9 @@ export const TestDiscoverTalentDropdownModal = ({
     }
   };
 
-  const handleBack = () => {
-    if (onPrev) onPrev!();
-  };
+  // const handleBack = () => {
+  //   if (onPrev) onPrev!();
+  // };
 
   useEffect(() => {
     const _numMatches = numMatches;
@@ -108,6 +107,7 @@ export const TestDiscoverTalentDropdownModal = ({
     if (selectedItems) {
       const selectedNodeId: string[] = [];
       const selectedNodeNames: string[] = [];
+
       forEach(selectedItems, (el) => {
         if (!isEmpty(el)) {
           forEach(el, (item) => {


### PR DESCRIPTION
this PR removes `context: { serviceName: "soilservice" },` from all mutations and queries as it's no longer needed

remove split link #994