### PR TITLE
feat: created "Match %" tab bottom section with summaryQuestions object

### DIFF
--- a/packages/ui/src/info/CandidateInfo/CandidateInfo.tsx
+++ b/packages/ui/src/info/CandidateInfo/CandidateInfo.tsx
@@ -39,7 +39,9 @@ export const CandidateInfo = ({
     },
     {
       tab: "MATCH %",
-      Content: () => <MatchTab member={member} />,
+      Content: () => (
+        <MatchTab member={member} summaryQuestions={summaryQuestions} />
+      ),
     },
     {
       tab: "GRAPH",

--- a/packages/ui/src/info/CandidateInfo/CandidateInfo.tsx
+++ b/packages/ui/src/info/CandidateInfo/CandidateInfo.tsx
@@ -1,4 +1,4 @@
-import { Members } from "@eden/package-graphql/generated";
+import { Members, SummaryQuestionType } from "@eden/package-graphql/generated";
 import { Avatar, Button, TextHeading3 } from "@eden/package-ui";
 import { Tab } from "@headlessui/react";
 import { useState } from "react";
@@ -12,7 +12,7 @@ export interface ICandidateInfoProps {
   member: Members;
   percentage: number | null;
   loading?: boolean;
-  summaryQuestions: any;
+  summaryQuestions: SummaryQuestionType[];
   handleCloseModal?: () => void;
 }
 
@@ -112,7 +112,7 @@ export const CandidateInfo = ({
                 className={({ selected }) =>
                   classNames(
                     selected
-                      ? "border-b-soilGreen-700 text-soilGreen-700 w-full border-b-4"
+                      ? "border-b-soilGreen-700 text-soilGreen-700 w-full border-b-4 outline-none"
                       : "font-avenir-roman w-full border-b-4 text-gray-400"
                   )
                 }
@@ -124,9 +124,9 @@ export const CandidateInfo = ({
           <Tab.Panels>
             {tabs.map(({ Content }, index) => (
               <Tab.Panel key={index}>
-                <>
+                <div className="relative">
                   <Content />
-                </>
+                </div>
               </Tab.Panel>
             ))}
           </Tab.Panels>

--- a/packages/ui/src/info/CandidateInfo/tabs/MatchTab.tsx
+++ b/packages/ui/src/info/CandidateInfo/tabs/MatchTab.tsx
@@ -1,14 +1,15 @@
-import { Members } from "@eden/package-graphql/generated";
+import { Members, SummaryQuestionType } from "@eden/package-graphql/generated";
 import {
   BackgroundMatchChart,
   TextHeading2,
+  TextInputLabel,
   TextLabel1,
 } from "@eden/package-ui";
 import React from "react";
 
 type Props = {
   member: Members;
-  summaryQuestions: any;
+  summaryQuestions: SummaryQuestionType[];
 };
 
 export const MatchTab: React.FC<Props> = ({ member, summaryQuestions }) => {
@@ -38,41 +39,7 @@ export const MatchTab: React.FC<Props> = ({ member, summaryQuestions }) => {
       averagePercentage: 40,
     },
   ];
-  const dataRow1 = [
-    {
-      title: "STRONGEST SKILLS",
-      percentage: 87,
-    },
-    {
-      title: "COMPLIMENTARY SKILLS",
-      percentage: 63,
-    },
-    {
-      title: "RELEVANT EXPERIENCE",
-      percentage: 30,
-    },
-    {
-      title: "CAREER GOALS",
-      percentage: 73,
-    },
-  ];
 
-  const dataRow2 = [
-    {
-      title: "LEADERSHIP",
-      shortAnswer: "6 years in leadership position",
-    },
-    {
-      title: "CORPO VS STARTUP",
-      shortAnswer: "Startup",
-    },
-    {
-      title: "INTRINSIC MOTIVATION",
-      shortAnswer: "Growth & connections",
-    },
-  ];
-
-  console.log({ summaryQuestions });
   return (
     <>
       <div className="mb-4 mt-4">
@@ -84,29 +51,39 @@ export const MatchTab: React.FC<Props> = ({ member, summaryQuestions }) => {
       <p className="text-soilHeading3 font-poppins mb-2 mt-6 text-center font-black text-gray-400">
         EXPERTISE
       </p>
-      <div className={`mx-auto my-4 grid grid-cols-${dataRow1.length} gap-4`}>
-        {dataRow1.map((item, index) => (
+      <div
+        className={`mx-auto my-4 grid grid-cols-${summaryQuestions.length} gap-4`}
+      >
+        {summaryQuestions.map((item, index) => (
           <div key={index}>
-            <div className="mx-auto flex h-16 w-32 items-center justify-center">
+            <div className="mx-auto flex h-16 w-auto items-center justify-center">
               <p className="text-center">
-                <TextLabel1 className="text-black">{item.title}</TextLabel1>
+                <TextLabel1 className="text-black">
+                  {item.questionContent}
+                </TextLabel1>
               </p>
             </div>
             <div className="mt-2">
               <div className="flex items-center justify-center">
-                <div className="text-3xl font-black">
-                  <TextHeading2
-                    className={`${
-                      index % 2
-                        ? "text-soilPurple"
-                        : index % 3
-                        ? "text-soilOrange"
-                        : "text-soilTurquoise"
-                    }`}
-                  >
-                    {item.percentage}%
-                  </TextHeading2>
-                </div>
+                {item.score ? (
+                  <div className="font-black">
+                    <TextHeading2
+                      className={`${
+                        index % 2
+                          ? "text-soilPurple"
+                          : index % 3
+                          ? "text-soilOrange"
+                          : "text-soilTurquoise"
+                      }`}
+                    >
+                      {item.score}%
+                    </TextHeading2>
+                  </div>
+                ) : (
+                  <TextInputLabel className="text-xs text-black">
+                    {item.answerContent}
+                  </TextInputLabel>
+                )}
               </div>
             </div>
           </div>
@@ -115,21 +92,22 @@ export const MatchTab: React.FC<Props> = ({ member, summaryQuestions }) => {
       <p className="text-soilHeading3 font-poppins mb-6 text-center font-black text-gray-400">
         CULTURE FIT
       </p>
-      <div className={`mx-auto grid grid-cols-${dataRow2.length} gap-4`}>
-        {dataRow2.map((item) => (
-          <div key={item.title}>
-            <div className="mx-auto flex h-16 w-32 items-center justify-center">
+      <div
+        className={`mx-auto grid grid-cols-${summaryQuestions.length} gap-4`}
+      >
+        {summaryQuestions.map((item, index) => (
+          <div key={index}>
+            <div className="mx-auto flex h-16 w-auto items-center justify-center">
               <p className="text-center">
-                <TextLabel1 className="text-black">{item.title}</TextLabel1>
+                <TextLabel1 className="text-black">
+                  {item.questionContent}
+                </TextLabel1>
               </p>
             </div>
-            <div
-              className="mx-auto flex h-16 w-32 items-center justify-center"
-              key={item.title}
-            >
+            <div className="mx-auto flex items-center justify-center">
               <p className="text-center">
                 <TextLabel1 className="text-soilPurple">
-                  {item.shortAnswer}
+                  {item.answerContent}
                 </TextLabel1>
               </p>
             </div>

--- a/packages/ui/src/info/CandidateInfo/tabs/MatchTab.tsx
+++ b/packages/ui/src/info/CandidateInfo/tabs/MatchTab.tsx
@@ -55,7 +55,7 @@ export const MatchTab: React.FC<Props> = ({ member, summaryQuestions }) => {
         className={`mx-auto my-4 grid grid-cols-${summaryQuestions.length} gap-4`}
       >
         {summaryQuestions.map((item, index) => (
-          <div key={index}>
+          <div key={index} className="hover:bg-blue-100">
             <div className="mx-auto flex h-16 w-auto items-center justify-center">
               <p className="text-center">
                 <TextLabel1 className="text-black">

--- a/packages/ui/src/info/CandidateInfo/tabs/MatchTab.tsx
+++ b/packages/ui/src/info/CandidateInfo/tabs/MatchTab.tsx
@@ -1,14 +1,17 @@
 import { Members } from "@eden/package-graphql/generated";
-import { BackgroundMatchChart } from "@eden/package-ui";
+import {
+  BackgroundMatchChart,
+  TextHeading2,
+  TextLabel1,
+} from "@eden/package-ui";
 import React from "react";
 
 type Props = {
   member: Members;
+  summaryQuestions: any;
 };
 
-export const MatchTab: React.FC<Props> = ({ member }) => {
-  console.log({ member });
-
+export const MatchTab: React.FC<Props> = ({ member, summaryQuestions }) => {
   const exampleData = [
     {
       questionID: "1242",
@@ -35,15 +38,103 @@ export const MatchTab: React.FC<Props> = ({ member }) => {
       averagePercentage: 40,
     },
   ];
+  const dataRow1 = [
+    {
+      title: "STRONGEST SKILLS",
+      percentage: 87,
+    },
+    {
+      title: "COMPLIMENTARY SKILLS",
+      percentage: 63,
+    },
+    {
+      title: "RELEVANT EXPERIENCE",
+      percentage: 30,
+    },
+    {
+      title: "CAREER GOALS",
+      percentage: 73,
+    },
+  ];
 
+  const dataRow2 = [
+    {
+      title: "LEADERSHIP",
+      shortAnswer: "6 years in leadership position",
+    },
+    {
+      title: "CORPO VS STARTUP",
+      shortAnswer: "Startup",
+    },
+    {
+      title: "INTRINSIC MOTIVATION",
+      shortAnswer: "Growth & connections",
+    },
+  ];
+
+  console.log({ summaryQuestions });
   return (
     <>
-      <div className="mb-4 mt-4 ">
-        MatchTab
+      <div className="mb-4 mt-4">
         <BackgroundMatchChart
           memberName={member.discordName ?? ""}
           backgroundMatchData={exampleData}
         />
+      </div>
+      <p className="text-soilHeading3 font-poppins mb-2 mt-6 text-center font-black text-gray-400">
+        EXPERTISE
+      </p>
+      <div className={`mx-auto my-4 grid grid-cols-${dataRow1.length} gap-4`}>
+        {dataRow1.map((item, index) => (
+          <div key={index}>
+            <div className="mx-auto flex h-16 w-32 items-center justify-center">
+              <p className="text-center">
+                <TextLabel1 className="text-black">{item.title}</TextLabel1>
+              </p>
+            </div>
+            <div className="mt-2">
+              <div className="flex items-center justify-center">
+                <div className="text-3xl font-black">
+                  <TextHeading2
+                    className={`${
+                      index % 2
+                        ? "text-soilPurple"
+                        : index % 3
+                        ? "text-soilOrange"
+                        : "text-soilTurquoise"
+                    }`}
+                  >
+                    {item.percentage}%
+                  </TextHeading2>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-soilHeading3 font-poppins mb-6 text-center font-black text-gray-400">
+        CULTURE FIT
+      </p>
+      <div className={`mx-auto grid grid-cols-${dataRow2.length} gap-4`}>
+        {dataRow2.map((item) => (
+          <div key={item.title}>
+            <div className="mx-auto flex h-16 w-32 items-center justify-center">
+              <p className="text-center">
+                <TextLabel1 className="text-black">{item.title}</TextLabel1>
+              </p>
+            </div>
+            <div
+              className="mx-auto flex h-16 w-32 items-center justify-center"
+              key={item.title}
+            >
+              <p className="text-center">
+                <TextLabel1 className="text-soilPurple">
+                  {item.shortAnswer}
+                </TextLabel1>
+              </p>
+            </div>
+          </div>
+        ))}
       </div>
     </>
   );

--- a/packages/ui/src/info/CandidateInfo/tabs/ScoresTab.tsx
+++ b/packages/ui/src/info/CandidateInfo/tabs/ScoresTab.tsx
@@ -1,11 +1,11 @@
-import { Members } from "@eden/package-graphql/generated";
+import { Members, SummaryQuestionType } from "@eden/package-graphql/generated";
 import { Avatar } from "@eden/package-ui";
 import React from "react";
 
 type Props = {
-  member: Members | null;
+  member: Members;
   percentage: number | null;
-  summaryQuestions: any;
+  summaryQuestions: SummaryQuestionType[];
 };
 
 export const ScoresTab: React.FC<Props> = ({


### PR DESCRIPTION
- created the columns for the data, first based on hardcoded data from the design, then changed it for the summaryQuestions object, repeated in both rows.
- lack of the fetch of more questions data, or more data to be loaded.

Image for reference: 

![image](https://user-images.githubusercontent.com/2791028/236585063-a9039693-c287-4328-872d-55565643e2a7.png)

How it looks now:

![image](https://user-images.githubusercontent.com/2791028/236585228-9656676b-c935-47c9-81d7-b60daa30524d.png)

As it's repeated data and the bottom answer are long, it looks a little messy. I believe when we have more data and we can discriminate it between "Expertise" and "Culture fit", it will look better


