### PR TITLE
feat: showing correctly the talentlist working on after creation or edition

### DIFF
--- a/apps/saas/pages/dashboard/[positionID].tsx
+++ b/apps/saas/pages/dashboard/[positionID].tsx
@@ -70,7 +70,7 @@ const PositionCRM: NextPageWithLayout = () => {
   const [selectedUserSummaryQuestions, setSelectedUserSummaryQuestions] =
     useState<any[]>([]);
 
-  console.log("candidates totot= ", candidates);
+  // console.log("candidates totot= ", candidates);
 
   const [questions, setQuestions] = useState<Question[]>([]);
 
@@ -97,6 +97,8 @@ const PositionCRM: NextPageWithLayout = () => {
   >([]);
 
   const [newTalentListName, setNewTalentListName] = useState<string>("");
+
+  const [talentListToShow, setTalentListToShow] = useState<TalentListType>();
 
   const {
     data: findPositionData,
@@ -328,9 +330,22 @@ const PositionCRM: NextPageWithLayout = () => {
           data?.updateUsersTalentListPosition.talentList[lastTalentListIndex];
 
         if (newList) {
-          setTalentListSelected({ _id: "000", name: "No list selected" });
-          if (!editTalentListMode)
-            setTalentListsAvailables([...talentListsAvailables, newList]);
+          if (editTalentListMode) {
+            setTalentListSelected(newList);
+            const candidatesOnTalentListSelected: CandidateTypeSkillMatch[] =
+              [];
+
+            for (let i = 0; i < candidates.length; i++) {
+              for (let j = 0; j < newList.talent!.length; j++) {
+                if (candidates[i].user?._id === newList.talent![j]!.user!._id) {
+                  candidatesOnTalentListSelected.push(candidates[i]);
+                }
+              }
+            }
+            setCandidatesFromTalentList(candidatesOnTalentListSelected);
+          } else {
+            setTalentListToShow(newList);
+          }
           setNewTalentListCreationMode(false);
           setEditTalentListMode(false);
           setNewTalentListCandidatesIds([]);
@@ -352,9 +367,21 @@ const PositionCRM: NextPageWithLayout = () => {
   const handleSelectedTalentList = (list: TalentListType) => {
     const candidatesOnTalentListSelected: CandidateTypeSkillMatch[] = [];
 
-    if (list._id !== "000") {
-      setNewTalentListCreationMode(false);
-
+    if (talentListToShow) {
+      // console.log("111 aaa");
+      for (let i = 0; i < candidates.length; i++) {
+        for (let j = 0; j < talentListToShow.talent!.length; j++) {
+          if (
+            candidates[i].user?._id === talentListToShow.talent![j]!.user!._id
+          ) {
+            candidatesOnTalentListSelected.push(candidates[i]);
+          }
+        }
+      }
+      setTalentListSelected(talentListToShow);
+      setTalentListToShow(undefined);
+    } else if (list._id !== "000") {
+      // console.log("1111 cccc");
       for (let i = 0; i < candidates.length; i++) {
         for (let j = 0; j < list.talent!.length; j++) {
           if (candidates[i].user?._id === list.talent![j]!.user!._id) {
@@ -365,13 +392,16 @@ const PositionCRM: NextPageWithLayout = () => {
       setTalentListSelected(list);
     } else {
       candidatesOnTalentListSelected.push(...candidates);
+      // console.log("1111 bbbb");
       setTalentListSelected({ _id: "000", name: "No list selected" });
     }
+    // }
 
     setCandidatesFromTalentList(candidatesOnTalentListSelected);
   };
 
   const handleCreateNewListButton = () => {
+    // console.log("2222");
     setTalentListSelected({ _id: "000", name: "No list selected" });
     setNewTalentListCreationMode(true);
     setCandidatesFromTalentList(candidates);

--- a/packages/ui/src/info/CandidateInfo/tabs/InfoTab.tsx
+++ b/packages/ui/src/info/CandidateInfo/tabs/InfoTab.tsx
@@ -31,7 +31,7 @@ export const InfoTab: FC<Props> = ({ member, mostRelevantMemberNode }) => {
   const [experienceOpen, setExperienceOpen] = useState<number | null>(null);
   const [seeMore, setSeeMore] = useState(false);
 
-  console.log("mostRelevantMemberNode 00303003 = ", mostRelevantMemberNode);
+  // console.log("mostRelevantMemberNode 00303003 = ", mostRelevantMemberNode);
 
   return (
     <>

--- a/packages/ui/src/lists/CandidatesTableList/CandidatesTableList.tsx
+++ b/packages/ui/src/lists/CandidatesTableList/CandidatesTableList.tsx
@@ -68,7 +68,7 @@ export const CandidatesTableList: FC<CandidatesTableListProps> = ({
     setRowObjectData(candidate);
   };
 
-  console.log("candidatesList = ", candidatesList);
+  // console.log("candidatesList = ", candidatesList);
 
   return (
     <section className="scrollbar-hide max-h-[calc(100vh-9.5rem)] w-full overflow-scroll rounded-md border border-gray-300 bg-white drop-shadow-md">


### PR DESCRIPTION
## Pull Request Description:

- showing the talent list recently created for the user ([TALD-57](https://linear.app/eden-protocol/issue/TALD-57/go-directly-to-new-list-when-is-creating-new-list))
- staying on the actual talent list after edition ([TALD-58](https://linear.app/eden-protocol/issue/TALD-58/when-edit-list-stay-on-the-correct-listid))

## Tested flows:
- created new talent list, and have it selected after creation
- selected any existing talent list, edited it, and have it selected after edition
- created a new talent list, and have it selected after creation (as first point), after this, edited this new talent list, and after edition the talent list continues selected.

* The most important thing on these tested user usage flows is the point that the talent list working on is not only being selected after any action on it, also the list of the talent (candidates) is being shown correctly, most important thing (I think), is after the edition, where we have to show the newest talent on the list table with the values calculated on the go, like the Skill Match, as a good example

### next steps:
- [TALD-62](https://linear.app/eden-protocol/issue/TALD-62/loader-when-create-or-edit-list) Work on a loader or something to improve the user experience (UX), **REALLY needed** ASAP, mostly because things are happening and for lag, etc, the user doesn't know anything so it might end in a confusion
- going to work on a refact that wold include the abstraction of a repeatedly used _function_ and I will surely wrap it in a useCallback hook just for the sake of the feature performance. Either way if it doesn't not make a **big** difference, just to have it done the best way possible so anyone from the team doesn't have to deal with it in the near future.

Thinking ahead, maybe to have the first point of the next steps working properly, I will have to approach the second point written above first